### PR TITLE
kiagnose: Introduce basic skeleton

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,12 +9,19 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  GO_VERSION: 1.17
+
 jobs:
-  noop:
-    name: noop 
+  unit-test:
+    name: Unit Test
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
       uses: actions/checkout@v2
-    - name: Hello Word
-      run: echo "Hello World"
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - name: Run unit tests
+      run: ./automation/make.sh --unit-test

--- a/automation/make.sh
+++ b/automation/make.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+#
+
+set -e
+
+options=$(getopt --options "" \
+    --long unit-test,help\
+    -- "${@}")
+eval set -- "$options"
+while true; do
+    case "$1" in
+    --unit-test)
+        OPT_UNIT_TEST=1
+        ;;
+    --help)
+        set +x
+        echo "$0 [--unit-test]"
+        exit
+        ;;
+    --)
+        shift
+        break
+        ;;
+    esac
+    shift
+done
+
+if [ -z "${OPT_UNIT_TEST}" ]; then
+    OPT_UNIT_TEST=1
+fi
+
+if [ -n "${OPT_UNIT_TEST}" ]; then
+    go test -v ./kiagnose/...
+fi

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kiagnose/kiagnose
+
+go 1.17

--- a/kiagnose/mainflow.go
+++ b/kiagnose/mainflow.go
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+ package kiagnose
+
+ func Run() error {
+	 return nil
+ }

--- a/kiagnose/mainflow_test.go
+++ b/kiagnose/mainflow_test.go
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package kiagnose_test
+
+import (
+	"testing"
+
+	"github.com/kiagnose/kiagnose/kiagnose"
+)
+
+func TestRun(t *testing.T) {
+    t.Run("kiagnose entry point (placeholder test)", func(t *testing.T) {
+        if err := kiagnose.Run(); err != nil {
+	    t.Errorf("failed execution of Run(): %v", err)
+	}
+    })
+}


### PR DESCRIPTION
Introducing the project skeleton, including a placeholder for the library entry-point, the script to run the tests and CI to run them on every PR.