### PR TITLE
linter: Introduce the golangci linter

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,6 +13,20 @@ env:
   GO_VERSION: 1.17
 
 jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.44.2
   unit-test:
     name: Unit Test
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,105 @@
+# golangci configuration
+
+linters-settings:
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  gci:
+    local-prefixes: github.com/kiagnose/kiagnose
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+      - wrapperFunc
+  gocyclo:
+    min-complexity: 15
+  goimports:
+    local-prefixes: github.com/kiagnose/kiagnose
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+  govet:
+    check-shadowing: true
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goheader
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+  # don't enable:
+  # - asciicheck
+  # - scopelint
+  # - gochecknoglobals
+  # - gocognit
+  # - godot
+  # - godox
+  # - goerr113
+  # - interfacer
+  # - maligned
+  # - nestif
+  # - prealloc
+  # - testpackage
+  # - revive
+  # - wsl

--- a/automation/make.sh
+++ b/automation/make.sh
@@ -25,12 +25,15 @@ options=$(getopt --options "" \
 eval set -- "$options"
 while true; do
     case "$1" in
+    --lint)
+        OPT_LINT=1
+        ;;
     --unit-test)
         OPT_UNIT_TEST=1
         ;;
     --help)
         set +x
-        echo "$0 [--unit-test]"
+        echo "$0 [--lint] [--unit-test]"
         exit
         ;;
     --)
@@ -41,8 +44,17 @@ while true; do
     shift
 done
 
-if [ -z "${OPT_UNIT_TEST}" ]; then
+if  [ -z "${OPT_LINT}" ] && [ -z "${OPT_UNIT_TEST}" ]; then
+    OPT_LINT=1
     OPT_UNIT_TEST=1
+fi
+
+if [ -n "${OPT_LINT}" ]; then
+    golangci_lint_version=v1.44.2
+    if [ ! -f $(go env GOPATH)/bin/golangci-lint ]; then
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $golangci_lint_version
+    fi
+    golangci-lint run
 fi
 
 if [ -n "${OPT_UNIT_TEST}" ]; then

--- a/kiagnose/mainflow.go
+++ b/kiagnose/mainflow.go
@@ -17,8 +17,8 @@
  *
  */
 
- package kiagnose
+package kiagnose
 
- func Run() error {
-	 return nil
- }
+func Run() error {
+	return nil
+}

--- a/kiagnose/mainflow_test.go
+++ b/kiagnose/mainflow_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestRun(t *testing.T) {
-    t.Run("kiagnose entry point (placeholder test)", func(t *testing.T) {
+	t.Run("kiagnose entry point (placeholder test)", func(t *testing.T) {
 		assert.NoError(t, kiagnose.Run())
-    })
+	})
 }


### PR DESCRIPTION
The golangci linter [1] will perform a static analisys
on the code.

Developers can run it locally using:
`./automation/make.sh --lint`

The CI will run it as a check.

Note: Existing formatting issues have been fixed in this PR.

[1] https://github.com/golangci/golangci-lint

~Depends on #1~ 