### PR TITLE
Add echo checkup

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -51,6 +51,14 @@ jobs:
         go-version: ${{ matrix.version }}
     - name: Run unit tests
       run: ./automation/make.sh --unit-test
+  echo-unit-test:
+    name: Echo checkup Unit Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run unit tests
+        run: ./automation/make.sh --echo-unit-test
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/automation/make.sh
+++ b/automation/make.sh
@@ -30,8 +30,12 @@ CORE_IMAGE="${IMAGE_REGISTRY}/${IMAGE_ORG}/${CORE_IMAGE_NAME}:${CORE_IMAGE_TAG}"
 
 CORE_BINARY_NAME="kiagnose"
 
+ECHO_CHECKUP_PATH="checkups/echo"
+ECHO_IMAGE_NAME="echo-checkup"
+ECHO_IMAGE_TAG=${ECHO_IMAGE_TAG:-devel}
+
 options=$(getopt --options "" \
-    --long lint,unit-test,build-core,build-core-image,push-core-image,echo-unit-test,help\
+    --long lint,unit-test,build-core,build-core-image,push-core-image,echo-unit-test,echo-build-image,help\
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -54,9 +58,12 @@ while true; do
     --echo-unit-test)
         OPT_ECHO_UNIT_TEST=1
         ;;
+    --echo-build-image)
+        OPT_ECHO_BUILD_IMAGE=1
+        ;;
     --help)
         set +x
-        echo "$0 [--lint] [--unit-test] [--build-core] [--build-core-image] [--push-core-image] [--echo-unit-test]"
+        echo "$0 [--lint] [--unit-test] [--build-core] [--build-core-image] [--push-core-image] [--echo-unit-test] [--echo-build-image]"
         exit
         ;;
     --)
@@ -67,7 +74,10 @@ while true; do
     shift
 done
 
-if  [ -z "${OPT_LINT}" ] && [ -z "${OPT_UNIT_TEST}" ] && [ -z "${OPT_BUILD_CORE}" ] && [ -z "${OPT_BUILD_CORE_IMAGE}" ] && [ -z "${OPT_PUSH_CORE_IMAGE}" ] && [ -z "${OPT_ECHO_UNIT_TEST}" ]; then
+
+if  [ -z "${OPT_LINT}" ] && [ -z "${OPT_UNIT_TEST}" ] && [ -z "${OPT_BUILD_CORE}" ] &&\
+    [ -z "${OPT_BUILD_CORE_IMAGE}" ] && [ -z "${OPT_PUSH_CORE_IMAGE}" ] &&\
+    [ -z "${OPT_ECHO_UNIT_TEST}" ] && [ -z "${OPT_ECHO_BUILD_IMAGE}" ]; then
     OPT_LINT=1
     OPT_UNIT_TEST=1
     OPT_BUILD_CORE=1
@@ -105,4 +115,10 @@ if [ -n "${OPT_ECHO_UNIT_TEST}" ]; then
   cd ./checkups/echo/
   ./entrypoint_test
   cd -
+fi
+
+if [ -n "${OPT_ECHO_BUILD_IMAGE}" ]; then
+    full_image_name="${ECHO_IMAGE_NAME}:${ECHO_IMAGE_TAG}"
+    echo "Trying to build image \"${full_image_name}\"..."
+    ${CRI} build ${ECHO_CHECKUP_PATH} --file ${ECHO_CHECKUP_PATH}/Dockerfile --tag "${full_image_name}"
 fi

--- a/automation/make.sh
+++ b/automation/make.sh
@@ -31,7 +31,7 @@ CORE_IMAGE="${IMAGE_REGISTRY}/${IMAGE_ORG}/${CORE_IMAGE_NAME}:${CORE_IMAGE_TAG}"
 CORE_BINARY_NAME="kiagnose"
 
 options=$(getopt --options "" \
-    --long lint,unit-test,build-core,build-core-image,push-core-image,help\
+    --long lint,unit-test,build-core,build-core-image,push-core-image,echo-unit-test,help\
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -51,9 +51,12 @@ while true; do
     --push-core-image)
         OPT_PUSH_CORE_IMAGE=1
         ;;
+    --echo-unit-test)
+        OPT_ECHO_UNIT_TEST=1
+        ;;
     --help)
         set +x
-        echo "$0 [--lint] [--unit-test] [--build-core] [--build-core-image] [--push-core-image]"
+        echo "$0 [--lint] [--unit-test] [--build-core] [--build-core-image] [--push-core-image] [--echo-unit-test]"
         exit
         ;;
     --)
@@ -64,7 +67,7 @@ while true; do
     shift
 done
 
-if  [ -z "${OPT_LINT}" ] && [ -z "${OPT_UNIT_TEST}" ] && [ -z "${OPT_BUILD_CORE}" ] && [ -z "${OPT_BUILD_CORE_IMAGE}" ] && [ -z "${OPT_PUSH_CORE_IMAGE}" ]; then
+if  [ -z "${OPT_LINT}" ] && [ -z "${OPT_UNIT_TEST}" ] && [ -z "${OPT_BUILD_CORE}" ] && [ -z "${OPT_BUILD_CORE_IMAGE}" ] && [ -z "${OPT_PUSH_CORE_IMAGE}" ] && [ -z "${OPT_ECHO_UNIT_TEST}" ]; then
     OPT_LINT=1
     OPT_UNIT_TEST=1
     OPT_BUILD_CORE=1
@@ -96,4 +99,10 @@ fi
 if [ -n "${OPT_PUSH_CORE_IMAGE}" ]; then
    echo "Pushing \"${CORE_IMAGE}\"..."
    ${CRI} push ${CORE_IMAGE} 
+fi
+
+if [ -n "${OPT_ECHO_UNIT_TEST}" ]; then
+  cd ./checkups/echo/
+  ./entrypoint_test
+  cd -
 fi

--- a/checkups/echo/Dockerfile
+++ b/checkups/echo/Dockerfile
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-240.1648458092
+
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" &&\
+    chmod 744 kubectl &&\
+    mv ./kubectl /usr/local/bin
+
+COPY ./entrypoint /usr/local/bin
+
+ENTRYPOINT entrypoint

--- a/checkups/echo/README.md
+++ b/checkups/echo/README.md
@@ -1,0 +1,53 @@
+# Echo checkup
+This is an example checkup, used as a reference for creating more realistic checkups for the [Kiagnose](https://github.com/kiagnose/kiagnose) project.
+
+## Inputs
+The checkup expects the following environment variables to be supplied:
+1. "RESULT_CONFIGMAP_NAMESPACE" - namespace of the results ConfigMap object.
+2. "RESULT_CONFIGMAP_NAME" - name of the results ConfigMap object.
+3. "MESSAGE" - a message to write to the results ConfigMap object.
+
+## Outputs
+The checkup writes its results to the `data` field of the results ConfigMap object:
+```yaml
+status.succeeded: "true"
+status.failureReason: ""
+status.result.echo: "$MESSAGE"
+```
+
+In case the "MESSAGE" environment variable is missing:
+```yaml
+status.succeeded: "false"
+status.failureReason: "MESSAGE environment variable is missing"
+```
+
+## Build Instructions
+### Prerequisites
+- You have [podman](https://podman.io/) or other container engine capable of building images.
+### Steps
+```bash
+$ ./automation/make.sh --echo-build-image
+# Using Docker to build the image:
+$ CRI=docker ./automation/make.sh --echo-build-image
+```
+
+## Manual Execution Instructions
+### Prerequisites
+- The checkup container is built, tagged and stored in a registry accessible to your cluster.
+- You have "Admin" permissions on the K8s cluster.
+- kubectl is configured to connect to your cluster.
+### Steps
+1. Deploy the checkup manifest using:
+```bash
+$ kubectl create -f manifests/dev/echo-checkup.yaml
+```
+
+2. To get the checkup results:
+```bash
+$ kubectl get configmap echo-checkup-results -n echo-checkup-ns -o yaml > results.yaml
+```
+
+3. To remove the created objects:
+```bash
+$ kubectl delete -f manifests/dev/echo-checkup.yaml
+```

--- a/checkups/echo/entrypoint
+++ b/checkups/echo/entrypoint
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+#
+
+# echo-checkup
+# Input:
+# The checkup expects the following environment variables to be supplied:
+#   RESULT_CONFIGMAP_NAMESPACE - namespace of result ConfigMap object
+#   RESULT_CONFIGMAP_NAME - name of result ConfigMap object
+#   MESSAGE: a message to write as a result back to the framework
+# Output:
+# Fills the data field of the ConfigMap object supplied by the framework with the following key-value pairs:
+#   status.succeeded: "true"
+#   status.failureReason: none
+#   status.result.echo: "$MESSAGE"
+
+KUBECTL=${KUBECTL:-kubectl}
+RESULTS_CM_MANIFEST="/tmp/result_configmap.yaml"
+
+check_required_env_vars_from_framework() {
+  if [ -z "$RESULT_CONFIGMAP_NAMESPACE" ]; then
+    echo "error: RESULT_CONFIGMAP_NAMESPACE is empty" >&2
+    return 1
+  fi
+
+  if [ -z "$RESULT_CONFIGMAP_NAME" ]; then
+    echo "error: RESULT_CONFIGMAP_NAME is empty" >&2
+    return 1
+  fi
+}
+
+check_required_env_vars_by_echo_checkup() {
+    if [ -z "$MESSAGE" ]; then
+      echo "Warning: MESSAGE is empty" >&2
+      return 1
+    fi
+}
+
+print_all_inputs() {
+  echo " - RESULT_CONFIGMAP_NAMESPACE: $RESULT_CONFIGMAP_NAMESPACE"
+  echo " - RESULT_CONFIGMAP_NAME: $RESULT_CONFIGMAP_NAME"
+  echo " - MESSAGE: $MESSAGE"
+}
+
+create_results_manifest_file() {
+  local output_file="$1"
+  local error="$2"
+
+  if [ -z "${error}" ]; then
+    cat <<EOF > "${output_file}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: $RESULT_CONFIGMAP_NAME
+  namespace: $RESULT_CONFIGMAP_NAMESPACE
+data:
+  status.succeeded: "true"
+  status.failureReason: ""
+  status.result.echo: "$MESSAGE"
+...
+EOF
+  else
+    cat <<EOF > "${output_file}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: $RESULT_CONFIGMAP_NAME
+  namespace: $RESULT_CONFIGMAP_NAMESPACE
+data:
+  status.succeeded: "false"
+  status.failureReason: "MESSAGE environment variable is missing"
+...
+EOF
+  fi
+
+}
+
+main() {
+  echo "*** Starting echo checkup ***"
+
+  if ! check_required_env_vars_from_framework; then
+    exit 1
+  fi
+
+  local message_var_is_missing
+  if ! check_required_env_vars_by_echo_checkup; then
+    message_var_is_missing=1
+  fi
+
+  print_all_inputs
+  create_results_manifest_file "${RESULTS_CM_MANIFEST}" "${message_var_is_missing}"
+
+  echo "Trying to patch the result ConfigMap object..."
+  ${KUBECTL} patch configmap "${RESULT_CONFIGMAP_NAME}" -n "${RESULT_CONFIGMAP_NAMESPACE}" --patch-file "${RESULTS_CM_MANIFEST}"
+  if [ "$?" -ne 0 ]; then
+    echo "error: Failed to patch result ConfigMap object" >&2
+  fi
+
+  echo "*** Done ***"
+  if [ -n "${message_var_is_missing}" ]; then
+    exit 2
+  fi
+}
+
+main

--- a/checkups/echo/entrypoint_test
+++ b/checkups/echo/entrypoint_test
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+#
+
+ACTUAL_CM_MANIFEST="/tmp/result_configmap.yaml"
+EXPECTED_CM_MANIFEST="/tmp/expected_cm_manifest.yaml"
+
+
+entrypoint_should_succeed_with_all_env_vars() {
+  echo "entrypoint should exit(0) with all required env variables"
+
+  RESULT_CONFIGMAP_NAMESPACE=ns1 \
+  RESULT_CONFIGMAP_NAME=cm1 \
+  MESSAGE="message 1" \
+  KUBECTL="./fake_kubectl" \
+  ./entrypoint &> /dev/null
+  if [ "$?" -ne 0 ]; then
+    return 1
+  fi
+
+  echo "Compare created yaml manifest"
+  cat <<EOF > ${EXPECTED_CM_MANIFEST}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+  namespace: ns1
+data:
+  status.succeeded: "true"
+  status.failureReason: ""
+  status.result.echo: "message 1"
+...
+EOF
+
+  if diff ${EXPECTED_CM_MANIFEST} ${ACTUAL_CM_MANIFEST}; then
+    rm -v ${EXPECTED_CM_MANIFEST}
+  else
+    rm -v ${EXPECTED_CM_MANIFEST}
+    return 1
+  fi
+}
+
+entrypoint_should_fail_without_env_vars() {
+  echo "entrypoint should exit(1) when all required env variables are missing"
+  ./entrypoint &> /dev/null
+  if [ "$?" -ne 1 ]; then
+    return 1
+  fi
+}
+
+entrypoint_should_fail_without_ns_env_var() {
+  echo "entrypoint should exit(1) when RESULT_CONFIGMAP_NAMESPACE env variable is missing"
+  RESULT_CONFIGMAP_NAME=cm1 \
+  MESSAGE="message 1" \
+  ./entrypoint &> /dev/null
+  if [ "$?" -ne 1 ]; then
+    return 1
+  fi
+}
+
+entrypoint_should_fail_without_name_env_var() {
+  echo "entrypoint should exit(1) when RESULT_CONFIGMAP_NAME env variable is missing"
+  RESULT_CONFIGMAP_NAMESPACE=ns1 \
+  MESSAGE="message 1" \
+  ./entrypoint &> /dev/null
+  if [ "$?" -ne 1 ]; then
+    return 1
+  fi
+}
+
+entrypoint_should_fail_without_message_env_var() {
+  echo "entrypoint should exit(2) when MESSAGE env variable is missing"
+  RESULT_CONFIGMAP_NAMESPACE=ns1 \
+  RESULT_CONFIGMAP_NAME=cm1 \
+  ./entrypoint &> /dev/null
+  if [ "$?" -ne 2 ]; then
+    return 1
+  fi
+
+  echo "Compare created yaml manifest"
+  cat <<EOF > ${EXPECTED_CM_MANIFEST}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+  namespace: ns1
+data:
+  status.succeeded: "false"
+  status.failureReason: "MESSAGE environment variable is missing"
+...
+EOF
+
+  if diff ${EXPECTED_CM_MANIFEST} ${ACTUAL_CM_MANIFEST}; then
+    rm -v ${EXPECTED_CM_MANIFEST}
+  else
+    rm -v ${EXPECTED_CM_MANIFEST}
+    return 1
+  fi
+}
+
+main() {
+  local failure
+  if entrypoint_should_succeed_with_all_env_vars; then
+    echo "PASSED"
+  else
+    failure=1
+    echo "FAILED"
+  fi
+
+  if entrypoint_should_fail_without_env_vars; then
+    echo "PASSED"
+  else
+    failure=1
+    echo "FAILED"
+  fi
+
+  if entrypoint_should_fail_without_ns_env_var; then
+    echo "PASSED"
+  else
+    failure=1
+    echo "FAILED"
+  fi
+
+  if entrypoint_should_fail_without_name_env_var; then
+    echo "PASSED"
+  else
+    failure=1
+    echo "FAILED"
+  fi
+
+  if entrypoint_should_fail_without_message_env_var; then
+    echo "PASSED"
+  else
+    failure=1
+    echo "FAILED"
+  fi
+
+  if [ -n "${failure}" ]; then
+    exit 1
+  fi
+}
+
+main

--- a/checkups/echo/fake_kubectl
+++ b/checkups/echo/fake_kubectl
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+#
+
+exit 0

--- a/checkups/echo/manifests/dev/echo-checkup.yaml
+++ b/checkups/echo/manifests/dev/echo-checkup.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: echo-checkup-ns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: echo-checkup-results
+  namespace: echo-checkup-ns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: echo-checkup-sa
+  namespace: echo-checkup-ns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: configmap-patcher
+  namespace: echo-checkup-ns
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "get", "patch" ]
+    resourceNames: ["echo-checkup-results"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: configmap-patcher-echo-checkup-sa
+  namespace: echo-checkup-ns
+subjects:
+  - kind: ServiceAccount
+    name: echo-checkup-sa
+    namespace: echo-checkup-ns
+roleRef:
+  kind: Role
+  name: configmap-patcher
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: echo-checkup
+  namespace: echo-checkup-ns
+spec:
+  activeDeadlineSeconds: 60
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: echo-checkup-sa
+      containers:
+        - name: echo
+          image: echo-checkup:devel
+          env:
+            - name: RESULT_CONFIGMAP_NAMESPACE
+              value: echo-checkup-ns
+            - name: RESULT_CONFIGMAP_NAME
+              value: echo-checkup-results
+            - name: MESSAGE
+              value: Hi!
+      restartPolicy: Never
+...


### PR DESCRIPTION
This adds a basic checkup that shall be used as:
1. A debugging tool for developing the project.
2. A reference to create more advanced and useful checkups.

The checkup basically receives a string as an input, and writes it without modification to it's output.

This adds an option to make.sh to unit test the checkup's entrypoint script:
```bash
./automation/make.sh --echo-unit-test
```

This adds an option to make.sh to build the checkup's image:
```bash
./automation/make.sh --echo-build-image
```
It supports podman as a default, with the ability to choose arbitrary container engines such as Docker:
```bash
CRI=docker ./automation/make.sh --echo-build-image
```
An image tag can also be set:
```bash
ECHO_IMAGE_TAG=0.1.0 ./automation/make.sh --echo-build-image
```
Signed-off-by: Orel Misan <omisan@redhat.com>