### PR TITLE
make.sh: Add lint long option

### DIFF
--- a/automation/make.sh
+++ b/automation/make.sh
@@ -20,7 +20,7 @@
 set -e
 
 options=$(getopt --options "" \
-    --long unit-test,help\
+    --long lint,unit-test,help\
     -- "${@}")
 eval set -- "$options"
 while true; do


### PR DESCRIPTION
`make.sh --lint` option was missing.

Signed-off-by: Orel Misan <omisan@redhat.com>