### PR TITLE
image: Build an image from cmd

### DIFF
--- a/automation/make.sh
+++ b/automation/make.sh
@@ -19,10 +19,14 @@
 
 set -e
 
+CRI=${CRI:-podman}
+
 CORE_BINARY_NAME="kiagnose"
+CORE_IMAGE_NAME="kiagnose"
+CORE_IMAGE_TAG=${CORE_IMAGE_TAG:-devel}
 
 options=$(getopt --options "" \
-    --long lint,unit-test,build-core,help\
+    --long lint,unit-test,build-core,build-core-image,help\
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -36,9 +40,12 @@ while true; do
     --build-core)
         OPT_BUILD_CORE=1
         ;;
+    --build-core-image)
+        OPT_BUILD_CORE_IMAGE=1
+        ;;
     --help)
         set +x
-        echo "$0 [--lint] [--unit-test] [--build-core]"
+        echo "$0 [--lint] [--unit-test] [--build-core] [--build-core-image]"
         exit
         ;;
     --)
@@ -49,7 +56,7 @@ while true; do
     shift
 done
 
-if  [ -z "${OPT_LINT}" ] && [ -z "${OPT_UNIT_TEST}" ] && [ -z "${OPT_BUILD_CORE}" ]; then
+if  [ -z "${OPT_LINT}" ] && [ -z "${OPT_UNIT_TEST}" ] && [ -z "${OPT_BUILD_CORE}" ] && [ -z "${OPT_BUILD_CORE_IMAGE}" ]; then
     OPT_LINT=1
     OPT_UNIT_TEST=1
     OPT_BUILD_CORE=1
@@ -71,4 +78,10 @@ if [ -n "${OPT_BUILD_CORE}" ]; then
   echo "Trying to build \"${CORE_BINARY_NAME}\"..."
   go build -v -o ./bin/${CORE_BINARY_NAME} ./kiagnose/cmd/
   echo "Successfully built \"${CORE_BINARY_NAME}\""
+fi
+
+if [ -n "${OPT_BUILD_CORE_IMAGE}" ]; then
+    full_image_name="${CORE_IMAGE_NAME}:${CORE_IMAGE_TAG}"
+    echo "Trying to build image \"${full_image_name}\"..."
+    ${CRI} build . --file dockerfiles/Dockerfile.kiagnose --tag "${full_image_name}"
 fi

--- a/dockerfiles/Dockerfile.kiagnose
+++ b/dockerfiles/Dockerfile.kiagnose
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-240.1648458092
+
+COPY ./bin/kiagnose /usr/bin
+
+CMD kiagnose


### PR DESCRIPTION
This adds a Dockerfile and a simple build system for the image:
```bash
./automation/make.sh --build-core-image
```

It supports podman as a default, with the ability to choose arbitrary CRIs such as Docker:
```bash
CRI=docker ./automation/make.sh --build-core-image
```

An image tag can also be set:
```bash
CORE_IMAGE_TAG=0.1.0 ./automation/make.sh --build-core-image
```

~~This PR depends on PR #21.~~