### PR TITLE
make.sh: Minor changes

### DIFF
--- a/automation/make.sh
+++ b/automation/make.sh
@@ -38,7 +38,7 @@ while true; do
         ;;
     --help)
         set +x
-        echo "$0 [--lint] [--unit-test]"
+        echo "$0 [--lint] [--unit-test] [--build-core]"
         exit
         ;;
     --)

--- a/automation/make.sh
+++ b/automation/make.sh
@@ -19,7 +19,7 @@
 
 set -e
 
-BINARY_NAME="kiagnose"
+CORE_BINARY_NAME="kiagnose"
 
 options=$(getopt --options "" \
     --long lint,unit-test,build-core,help\
@@ -68,7 +68,7 @@ if [ -n "${OPT_UNIT_TEST}" ]; then
 fi
 
 if [ -n "${OPT_BUILD_CORE}" ]; then
-  echo "Trying to build \"${BINARY_NAME}\"..."
-  go build -v -o ./bin/${BINARY_NAME} ./kiagnose/cmd/
-  echo "Successfully built \"${BINARY_NAME}\""
+  echo "Trying to build \"${CORE_BINARY_NAME}\"..."
+  go build -v -o ./bin/${CORE_BINARY_NAME} ./kiagnose/cmd/
+  echo "Successfully built \"${CORE_BINARY_NAME}\""
 fi


### PR DESCRIPTION
This PR adds the `--build-core` option to `make.sh --help`.
Furthermore it changes `BINARY_NAME` variable name to `CORE_BINARY_NAME` in order to differentiate the core binary from future checkups binaries. 