### PR TITLE
main: Unexport envToMap()

### DIFF
--- a/kiagnose/cmd/environment.go
+++ b/kiagnose/cmd/environment.go
@@ -21,7 +21,7 @@ package main
 
 import "strings"
 
-func EnvToMap(rawEnv []string) map[string]string {
+func envToMap(rawEnv []string) map[string]string {
 	const requiredElementsCount = 2
 
 	env := map[string]string{}

--- a/kiagnose/cmd/main.go
+++ b/kiagnose/cmd/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 func main() {
-	env := EnvToMap(os.Environ())
+	env := envToMap(os.Environ())
 	if err := kiagnose.Run(env); err != nil {
 		log.Fatalf("%s had failed: %v", os.Args[0], err)
 	}


### PR DESCRIPTION
Since main() and envToMap() are both in the "main" package,
there is no need for envToMap() to be exported.

Signed-off-by: Orel Misan <omisan@redhat.com>