### PR TITLE
actions, publish: Push the main core image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,41 @@
+name: publish
+
+on:
+  push:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  go-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.versions.outputs.matrix }}
+      minimal: ${{ steps.versions.outputs.minimal }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arnested/go-version-action@v1
+        id: versions
+  publish:
+    runs-on: ubuntu-latest
+    needs: go-versions
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ needs.go-versions.outputs.minimal }}
+      - name: Build binary and core image
+        env:
+          CORE_IMAGE_TAG: main
+        run: ./automation/make.sh --build-core --build-core-image
+      - name: Log in to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+          registry: quay.io
+      - name: Push to quay.io
+        run: podman push quay.io/kiagnose/kiagnose:main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: go-versions
+    env:
+      CORE_IMAGE_TAG: main
+      CRI: podman
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -27,15 +30,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ needs.go-versions.outputs.minimal }}
-      - name: Build binary and core image
-        env:
-          CORE_IMAGE_TAG: main
-        run: ./automation/make.sh --build-core --build-core-image
-      - name: Log in to Quay.io
-        uses: redhat-actions/podman-login@v1
-        with:
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_TOKEN }}
-          registry: quay.io
-      - name: Push to quay.io
-        run: podman push quay.io/kiagnose/kiagnose:main
+      - name: Logging to quay.io
+        run: 
+          ${CRI} login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+      - name: Build and push core image
+        run: ./automation/make.sh --build-core --build-core-image --push-core-image

--- a/automation/make.sh
+++ b/automation/make.sh
@@ -22,6 +22,8 @@ set -e
 CRI=${CRI:-podman}
 
 CORE_BINARY_NAME="kiagnose"
+CORE_IMAGE_REPO=${CORE_IMAGE_REPO:-quay.io}
+CORE_IMAGE_ORG=${CORE_IMAGE_ORG:-kiagnose}
 CORE_IMAGE_NAME="kiagnose"
 CORE_IMAGE_TAG=${CORE_IMAGE_TAG:-devel}
 
@@ -81,7 +83,7 @@ if [ -n "${OPT_BUILD_CORE}" ]; then
 fi
 
 if [ -n "${OPT_BUILD_CORE_IMAGE}" ]; then
-    full_image_name="${CORE_IMAGE_NAME}:${CORE_IMAGE_TAG}"
+    full_image_name="${CORE_IMAGE_REPO}/${CORE_IMAGE_ORG}/${CORE_IMAGE_NAME}:${CORE_IMAGE_TAG}"
     echo "Trying to build image \"${full_image_name}\"..."
     ${CRI} build . --file dockerfiles/Dockerfile.kiagnose --tag "${full_image_name}"
 fi


### PR DESCRIPTION
After a PR is merge the kiagnose core image has to be pushed so users
can consume it. This change push the core kiagnose image on PR merges at
quay.io/kiagnose/kiagnose:main.

Notes for reviewers:
This cannot be tested on the PR since secrets are not passed to jobs running at PRs.
Tested with [act](https://github.com/nektos/act)