### PR TITLE
Start and wait for a checkup Job to finish

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -285,6 +285,10 @@ func (c *Checkup) Run() error {
 		return err
 	}
 
+	if c.job, err = job.WaitForJobToFinish(c.client.BatchV1(), c.job, c.jobTimeout); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/kiagnose/internal/checkup/job/job.go
+++ b/kiagnose/internal/checkup/job/job.go
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package job
+
+import (
+	"context"
+	"log"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
+)
+
+func Create(client batchv1client.BatchV1Interface, job *batchv1.Job) (*batchv1.Job, error) {
+	job, err := client.Jobs(job.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Job '%s/%s' successfully created", job.Namespace, job.Name)
+	return job, nil
+}

--- a/kiagnose/internal/checkup/job/job.go
+++ b/kiagnose/internal/checkup/job/job.go
@@ -21,10 +21,15 @@ package job
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8swatch "k8s.io/apimachinery/pkg/watch"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 )
 
@@ -35,4 +40,56 @@ func Create(client batchv1client.BatchV1Interface, job *batchv1.Job) (*batchv1.J
 	}
 	log.Printf("Job '%s/%s' successfully created", job.Namespace, job.Name)
 	return job, nil
+}
+
+func WaitForJobToFinish(client batchv1client.BatchV1Interface, job *batchv1.Job, timeout time.Duration) (*batchv1.Job, error) {
+	const JobNameLabel = "job-name"
+
+	jobLabel := fmt.Sprintf("%s=%s", JobNameLabel, job.Name)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	jobWatcher, err := client.Jobs(job.Namespace).Watch(ctx, metav1.ListOptions{LabelSelector: jobLabel})
+	if err != nil {
+		return nil, err
+	}
+
+	finishedJob, err := waitForJob(ctx, jobWatcher)
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for Job '%s/%s' to finish: %v", job.Namespace, job.Name, err)
+	}
+	log.Printf("Job '%s/%s' is finished", job.Namespace, job.Name)
+
+	return finishedJob, nil
+}
+
+func waitForJob(ctx context.Context, watcher k8swatch.Interface) (*batchv1.Job, error) {
+	eventsCh := watcher.ResultChan()
+	defer watcher.Stop()
+	for {
+		select {
+		case event := <-eventsCh:
+			job, ok := event.Object.(*batchv1.Job)
+			if !ok {
+				continue
+			}
+			if finished(job) {
+				if jobStatus, err := json.MarshalIndent(job.Status, "", " "); err == nil {
+					log.Printf("received job event '%s/%s': \n%v\n", job.Namespace, job.Name, string(jobStatus))
+				}
+				return job, nil
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func finished(job *batchv1.Job) bool {
+	for _, condition := range job.Status.Conditions {
+		if (condition.Type == batchv1.JobComplete || condition.Type == batchv1.JobFailed) &&
+			condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This PR introduce the logic for actually executing a checkup in a cluster.

With this PR changes the framework will create a batch Job to run the checkup image
and waits for it to finish.

A Job is considered as finished when its status has 'Completed' or 'Failed' condition.