### PR TITLE
checkups: Introduce kubevirt-vm-latency skeleton

### DIFF
--- a/.github/workflows/checkup-kubevirt-vm-latency.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.yaml
@@ -1,0 +1,72 @@
+name: checkup-kubevirt-vm-latency-checks
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  go-versions:
+    name: Lookup go versions
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./checkups/kubevirt-vm-latency
+    outputs:
+      matrix: ${{ steps.versions.outputs.matrix }}
+      minimal: ${{ steps.versions.outputs.minimal }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arnested/go-version-action@v1
+        id: versions
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    needs: go-versions
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ needs.go-versions.outputs.minimal }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.44.2
+          working-directory: ./checkups/kubevirt-vm-latency
+  unit-test:
+    name: Unit Test
+    runs-on: ubuntu-latest
+    needs: go-versions
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.version }}
+    - name: Run unit tests
+      working-directory: ./checkups/kubevirt-vm-latency
+      run: ./automation/make.sh --unit-test
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: go-versions
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ needs.go-versions.outputs.minimal }}
+      - name: Run build
+        working-directory: ./checkups/kubevirt-vm-latency
+        run: ./automation/make.sh --build-checkup

--- a/checkups/kubevirt-vm-latency/Dockerfile
+++ b/checkups/kubevirt-vm-latency/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-240.1648458092
+
+COPY ./bin/kubevirt-vm-latency /usr/bin
+
+CMD kubevirt-vm-latency

--- a/checkups/kubevirt-vm-latency/automation/make.sh
+++ b/checkups/kubevirt-vm-latency/automation/make.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+#
+
+set -e
+
+CRI=${CRI:-podman}
+
+CHECKUP_BINARY_NAME="kubevirt-vm-latency"
+CHECKUP_IMAGE_NAME="kubevirt-vm-latency"
+CHECKUP_IMAGE_TAG=${CORE_IMAGE_TAG:-devel}
+
+options=$(getopt --options "" \
+    --long lint,unit-test,build-checkup,build-checkup-image,help\
+    -- "${@}")
+eval set -- "$options"
+while true; do
+    case "$1" in
+    --lint)
+        OPT_LINT=1
+        ;;
+    --unit-test)
+        OPT_UNIT_TEST=1
+        ;;
+    --build-core)
+        OPT_BUILD_CHECKUP=1
+        ;;
+    --build-core-image)
+        OPT_BUILD_CHECKUP_IMAGE=1
+        ;;
+    --help)
+        set +x
+        echo "$0 [--lint] [--unit-test] [--build-checkup] [--build-checkup-image]"
+        exit
+        ;;
+    --)
+        shift
+        break
+        ;;
+    esac
+    shift
+done
+
+if  [ -z "${OPT_LINT}" ] && [ -z "${OPT_UNIT_TEST}" ] && [ -z "${OPT_BUILD_CHECKUP}" ] && [ -z "${OPT_BUILD_CHECKUP_IMAGE}" ]; then
+    OPT_LINT=1
+    OPT_UNIT_TEST=1
+    OPT_BUILD_CHECKUP=1
+fi
+
+if [ -n "${OPT_LINT}" ]; then
+    golangci_lint_version=v1.44.2
+    if [ ! -f $(go env GOPATH)/bin/golangci-lint ]; then
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $golangci_lint_version
+    fi
+    golangci-lint run
+fi
+
+if [ -n "${OPT_UNIT_TEST}" ]; then
+    go test -v ./...
+fi
+
+if [ -n "${OPT_BUILD_CHECKUP}" ]; then
+  echo "Trying to build \"${CHECKUP_BINARY_NAME}\"..."
+  go build -v -o ./bin/${CHECKUP_BINARY_NAME} ./cmd/
+  echo "Successfully built \"${CHECKUP_BINARY_NAME}\""
+fi
+
+if [ -n "${OPT_BUILD_CHECKUP_IMAGE}" ]; then
+    full_image_name="${CHECKUP_IMAGE_NAME}:${CHECKUP_IMAGE_TAG}"
+    echo "Trying to build image \"${full_image_name}\"..."
+    ${CRI} build . --file Dockerfile --tag "${full_image_name}"
+fi

--- a/checkups/kubevirt-vm-latency/cmd/main.go
+++ b/checkups/kubevirt-vm-latency/cmd/main.go
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import "log"
+
+func main() {
+	log.Println("Hello World")
+}

--- a/checkups/kubevirt-vm-latency/go.mod
+++ b/checkups/kubevirt-vm-latency/go.mod
@@ -1,0 +1,3 @@
+module github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency
+
+go 1.17


### PR DESCRIPTION
Add the kubevirt VM latency checkup skeleton as a submodule.

It includes:
- Placeholder main().
- Automation scripts (`make.sh`) to linter, unit test, build and create
  a container image.
- Dockerfile.

Note that the scripts on the submode should be executed under
`checkups/kubevirt-vm-latency`.