### PR TITLE
manifests: Add installation manifest

### DIFF
--- a/manifests/kiagnose.yaml
+++ b/manifests/kiagnose.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kiagnose
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kiagnose
+  namespace: kiagnose
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kiagnose
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+  - apiGroups: [ "" ]
+    resources: [ "namespaces" ]
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+  - apiGroups: [ "" ]
+    resources: [ "serviceaccounts" ]
+    verbs:
+      - get
+      - list
+      - create
+  - apiGroups: [ "rbac.authorization.k8s.io" ]
+    resources:
+      - roles
+      - clusterroles
+      - rolebindings
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - create
+  - apiGroups: [ "batch" ]
+    resources: [ "jobs" ]
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kiagnose
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kiagnose
+subjects:
+  - kind: ServiceAccount
+    name: kiagnose
+    namespace: kiagnose
+...


### PR DESCRIPTION
This adds the required K8s objects for the framework to work:
Namespace, ServiceAccount, ClusterRole and ClusterRoleBinding.

To install the framework:
```bash
$ kubectl apply -f manifests/kiagnose.yaml
```

To remove the framework:
```bash
$ kubectl delete -f manifests/kiagnose.yaml
```
Signed-off-by: Orel Misan <omisan@redhat.com>