### PR TITLE
echo-checkup: Add production manifest

### DIFF
--- a/checkups/echo/manifests/echo-checkup.yaml
+++ b/checkups/echo/manifests/echo-checkup.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: echo-checkup-config
+  namespace: kiagnose
+data:
+  spec.image: quay.io/kiagnose/echo-checkup:main
+  spec.timeout: 1m
+  spec.param.message: "Hi!"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: echo-checkup1
+  namespace: kiagnose
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccount: kiagnose
+      restartPolicy: Never
+      containers:
+        - name: framework
+          image: quay.io/kiagnose/kiagnose:main
+          imagePullPolicy: Always
+          env:
+            - name: CONFIGMAP_NAMESPACE
+              value: kiagnose
+            - name: CONFIGMAP_NAME
+              value: echo-checkup-config
+...


### PR DESCRIPTION
This adds a manifest to configure and run the echo-checkup.

Note: The following instructions assume the framework is installed.

To run the echo checkup:
```bash
$ kubectl apply -f checkups/echo/manifests/echo-checkup.yaml
```

To view the results:
```bash
$ kubectl get configmap echo-checkup-example-config -n kiagnose -o yaml
```
To delete all objects created by this manifest:
```bash
$ kubectl delete -f checkups/echo/manifests/echo-checkup.yaml
```

This PR depends on PR #36.

Signed-off-by: Orel Misan <omisan@redhat.com>