### PR TITLE
automation: Use defaults when no args are provided

### DIFF
--- a/automation/make.sh
+++ b/automation/make.sh
@@ -19,6 +19,8 @@
 
 set -e
 
+ARGCOUNT=$#
+
 CRI=${CRI:-podman}
 
 IMAGE_REGISTRY=${IMAGE_REGISTRY:-quay.io}
@@ -64,9 +66,7 @@ while true; do
     shift
 done
 
-
-if  [ -z "${OPT_LINT}" ] && [ -z "${OPT_UNIT_TEST}" ] && [ -z "${OPT_BUILD_CORE}" ] &&\
-    [ -z "${OPT_BUILD_CORE_IMAGE}" ] && [ -z "${OPT_PUSH_CORE_IMAGE}" ]; then
+if [ "${ARGCOUNT}" -eq "0" ] ; then
     OPT_LINT=1
     OPT_UNIT_TEST=1
     OPT_BUILD_CORE=1

--- a/checkups/kubevirt-vm-latency/automation/make.sh
+++ b/checkups/kubevirt-vm-latency/automation/make.sh
@@ -19,6 +19,8 @@
 
 set -e
 
+ARGCOUNT=$#
+
 CRI=${CRI:-podman}
 
 IMAGE_REGISTRY=${IMAGE_REGISTRY:-quay.io}
@@ -63,7 +65,7 @@ while true; do
     shift
 done
 
-if  [ -z "${OPT_LINT}" ] && [ -z "${OPT_UNIT_TEST}" ] && [ -z "${OPT_BUILD_CHECKUP}" ] && [ -z "${OPT_BUILD_CHECKUP_IMAGE}" ] && [ -z "${OPT_PUSH_CHECKUP_IMAGE}" ]; then
+if [ "${ARGCOUNT}" -eq "0" ] ; then
     OPT_LINT=1
     OPT_UNIT_TEST=1
     OPT_BUILD_CHECKUP=1


### PR DESCRIPTION
The current default handling in the automation scripts are not scalable.
Each time a new argument is added, there is a need to also add it
to the default handling condition.

With this change, instead of checking if each specific argument is not
set, a global check is done against the number of arguments the script
is called with. If no arguments are provided, the default options are
triggered.

> *_Note_*: Depends on #38