### PR TITLE
configmap: Change GetData() to Get()

### DIFF
--- a/kiagnose/internal/config/config.go
+++ b/kiagnose/internal/config/config.go
@@ -41,12 +41,12 @@ type Config struct {
 }
 
 func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMapName string) (*Config, error) {
-	rawData, err := configmap.GetData(client.CoreV1(), configMapNamespace, configMapName)
+	configMap, err := configmap.Get(client.CoreV1(), configMapNamespace, configMapName)
 	if err != nil {
 		return nil, err
 	}
 
-	parser := newConfigMapParser(rawData)
+	parser := newConfigMapParser(configMap.Data)
 	err = parser.Parse()
 	if err != nil {
 		return nil, err

--- a/kiagnose/internal/config/config.go
+++ b/kiagnose/internal/config/config.go
@@ -41,7 +41,7 @@ type Config struct {
 }
 
 func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMapName string) (*Config, error) {
-	rawData, err := configmap.GetData(client, configMapNamespace, configMapName)
+	rawData, err := configmap.GetData(client.CoreV1(), configMapNamespace, configMapName)
 	if err != nil {
 		return nil, err
 	}

--- a/kiagnose/internal/configmap/configmap.go
+++ b/kiagnose/internal/configmap/configmap.go
@@ -25,7 +25,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
@@ -38,8 +37,8 @@ func Create(client corev1client.CoreV1Interface, cm *corev1.ConfigMap) (*corev1.
 	return createdConfigMap, nil
 }
 
-func GetData(client kubernetes.Interface, namespace, name string) (map[string]string, error) {
-	configMap, err := client.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
+func GetData(client corev1client.CoreV1Interface, namespace, name string) (map[string]string, error) {
+	configMap, err := client.ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/kiagnose/internal/configmap/configmap.go
+++ b/kiagnose/internal/configmap/configmap.go
@@ -37,11 +37,6 @@ func Create(client corev1client.CoreV1Interface, cm *corev1.ConfigMap) (*corev1.
 	return createdConfigMap, nil
 }
 
-func GetData(client corev1client.CoreV1Interface, namespace, name string) (map[string]string, error) {
-	configMap, err := client.ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return configMap.Data, nil
+func Get(client corev1client.CoreV1Interface, namespace, name string) (*corev1.ConfigMap, error) {
+	return client.ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
 }


### PR DESCRIPTION
This PR changes `configmap.GetData()` to `configmap.Get()` which returns the full ConfigMap object instead of just its Data field.
Another minor change is changing the client type to `CoreV1Interface` in order to match `configmap.Create()` signature.