### PR TITLE
automation/CI: Exclude linting checkups, bump lint version, add verbosity and increase timeout

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.44.2
+          version: v1.45.2
           args: kiagnose/... cmd/...
   unit-test:
     name: Unit Test

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.45.2
-          args: kiagnose/... cmd/...
+          args: --timeout 3m --verbose kiagnose/... cmd/...
   unit-test:
     name: Unit Test
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,6 +35,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.44.2
+          args: kiagnose/... cmd/...
   unit-test:
     name: Unit Test
     runs-on: ubuntu-latest

--- a/automation/make.sh
+++ b/automation/make.sh
@@ -88,7 +88,7 @@ if  [ -z "${OPT_LINT}" ] && [ -z "${OPT_UNIT_TEST}" ] && [ -z "${OPT_BUILD_CORE}
 fi
 
 if [ -n "${OPT_LINT}" ]; then
-    golangci_lint_version=v1.44.2
+    golangci_lint_version=v1.45.2
     if [ ! -f $(go env GOPATH)/bin/golangci-lint ]; then
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $golangci_lint_version
     fi

--- a/automation/make.sh
+++ b/automation/make.sh
@@ -92,7 +92,7 @@ if [ -n "${OPT_LINT}" ]; then
     if [ ! -f $(go env GOPATH)/bin/golangci-lint ]; then
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $golangci_lint_version
     fi
-    golangci-lint run
+    golangci-lint run kiagnose/... cmd/...
 fi
 
 if [ -n "${OPT_UNIT_TEST}" ]; then


### PR DESCRIPTION
Optimize and fix lint issues:
- Run root lint on the `kiagnose` and `cmd` folders (excluse `checkups`).
- Bump lint version.
- Add verbosity to the run (to see where is time consumed).
- Increase timeout (as the current one started failing).