### PR TITLE
reporter: Add basic reporting capability

### DIFF
--- a/kiagnose/internal/configmap/configmap.go
+++ b/kiagnose/internal/configmap/configmap.go
@@ -40,3 +40,7 @@ func Create(client corev1client.CoreV1Interface, cm *corev1.ConfigMap) (*corev1.
 func Get(client corev1client.CoreV1Interface, namespace, name string) (*corev1.ConfigMap, error) {
 	return client.ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
 }
+
+func Update(client corev1client.CoreV1Interface, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return client.ConfigMaps(configMap.Namespace).Update(context.Background(), configMap, metav1.UpdateOptions{})
+}

--- a/kiagnose/internal/launcher/launcher.go
+++ b/kiagnose/internal/launcher/launcher.go
@@ -57,6 +57,7 @@ func (l Launcher) Run() (runErr error) {
 
 	defer func() {
 		statusData.Succeeded = false
+		statusData.FailureReason = "Failure: implement me"
 		statusData.CompletionTimestamp = time.Now()
 
 		if reportErr := l.reporter.Report(statusData); reportErr != nil {

--- a/kiagnose/internal/launcher/launcher.go
+++ b/kiagnose/internal/launcher/launcher.go
@@ -21,6 +21,9 @@ package launcher
 
 import (
 	"fmt"
+	"time"
+
+	"github.com/kiagnose/kiagnose/kiagnose/internal/status"
 )
 
 type workload interface {
@@ -30,7 +33,7 @@ type workload interface {
 }
 
 type reporter interface {
-	Report() error
+	Report(status.Status) error
 }
 
 type Launcher struct {
@@ -46,8 +49,14 @@ func New(checkup workload, reporter reporter) Launcher {
 }
 
 func (l Launcher) Run() (runErr error) {
+	statusData := status.Status{StartTimestamp: time.Now()}
+
+	if err := l.reporter.Report(statusData); err != nil {
+		return err
+	}
+
 	defer func() {
-		if reportErr := l.reporter.Report(); reportErr != nil {
+		if reportErr := l.reporter.Report(statusData); reportErr != nil {
 			if runErr != nil {
 				runErr = fmt.Errorf("%v, %v", runErr, reportErr)
 			} else {

--- a/kiagnose/internal/launcher/launcher.go
+++ b/kiagnose/internal/launcher/launcher.go
@@ -56,6 +56,7 @@ func (l Launcher) Run() (runErr error) {
 	}
 
 	defer func() {
+		statusData.Succeeded = false
 		statusData.CompletionTimestamp = time.Now()
 
 		if reportErr := l.reporter.Report(statusData); reportErr != nil {

--- a/kiagnose/internal/launcher/launcher.go
+++ b/kiagnose/internal/launcher/launcher.go
@@ -56,6 +56,8 @@ func (l Launcher) Run() (runErr error) {
 	}
 
 	defer func() {
+		statusData.CompletionTimestamp = time.Now()
+
 		if reportErr := l.reporter.Report(statusData); reportErr != nil {
 			if runErr != nil {
 				runErr = fmt.Errorf("%v, %v", runErr, reportErr)

--- a/kiagnose/internal/reporter/reporter.go
+++ b/kiagnose/internal/reporter/reporter.go
@@ -19,13 +19,63 @@
 
 package reporter
 
+import (
+	"errors"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kiagnose/kiagnose/kiagnose/internal/configmap"
+	"github.com/kiagnose/kiagnose/kiagnose/internal/status"
+)
+
+const StartTimestampKey = "status.startTimestamp"
+
+var ErrConfigMapDataIsNil = errors.New("configMap Data is nil")
+
 type Reporter struct {
+	client    kubernetes.Interface
+	configMap *corev1.ConfigMap
 }
 
-func New() Reporter {
-	return Reporter{}
+func New(client kubernetes.Interface, configMapNamespace, configMapName string) *Reporter {
+	return &Reporter{
+		client: client,
+		configMap: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: configMapNamespace,
+			},
+		},
+	}
 }
 
-func (r Reporter) Report() error {
+func (r *Reporter) Report(statusData status.Status) error {
+	if r.configMap.Data == nil {
+		configMap, err := configmap.Get(r.client.CoreV1(), r.configMap.Namespace, r.configMap.Name)
+		if err != nil {
+			return err
+		}
+
+		r.configMap = configMap
+	}
+
+	if r.configMap.Data == nil {
+		return ErrConfigMapDataIsNil
+	}
+
+	if !statusData.StartTimestamp.IsZero() {
+		r.configMap.Data[StartTimestampKey] = statusData.StartTimestamp.Format(time.RFC3339)
+	}
+
+	updatedConfigMap, err := configmap.Update(r.client.CoreV1(), r.configMap)
+	if err != nil {
+		return err
+	}
+
+	r.configMap = updatedConfigMap
+
 	return nil
 }

--- a/kiagnose/internal/reporter/reporter.go
+++ b/kiagnose/internal/reporter/reporter.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	SucceededKey           = "status.succeeded"
+	FailureReasonKey       = "status.failureReason"
 	StartTimestampKey      = "status.startTimestamp"
 	CompletionTimestampKey = "status.completionTimestamp"
 )
@@ -78,6 +79,7 @@ func (r *Reporter) Report(statusData status.Status) error {
 	if !statusData.CompletionTimestamp.IsZero() {
 		r.configMap.Data[CompletionTimestampKey] = statusData.CompletionTimestamp.Format(time.RFC3339)
 		r.configMap.Data[SucceededKey] = strconv.FormatBool(statusData.Succeeded)
+		r.configMap.Data[FailureReasonKey] = statusData.FailureReason
 	}
 
 	updatedConfigMap, err := configmap.Update(r.client.CoreV1(), r.configMap)

--- a/kiagnose/internal/reporter/reporter.go
+++ b/kiagnose/internal/reporter/reporter.go
@@ -31,7 +31,10 @@ import (
 	"github.com/kiagnose/kiagnose/kiagnose/internal/status"
 )
 
-const StartTimestampKey = "status.startTimestamp"
+const (
+	StartTimestampKey      = "status.startTimestamp"
+	CompletionTimestampKey = "status.completionTimestamp"
+)
 
 var ErrConfigMapDataIsNil = errors.New("configMap Data is nil")
 
@@ -68,6 +71,10 @@ func (r *Reporter) Report(statusData status.Status) error {
 
 	if !statusData.StartTimestamp.IsZero() {
 		r.configMap.Data[StartTimestampKey] = statusData.StartTimestamp.Format(time.RFC3339)
+	}
+
+	if !statusData.CompletionTimestamp.IsZero() {
+		r.configMap.Data[CompletionTimestampKey] = statusData.CompletionTimestamp.Format(time.RFC3339)
 	}
 
 	updatedConfigMap, err := configmap.Update(r.client.CoreV1(), r.configMap)

--- a/kiagnose/internal/reporter/reporter.go
+++ b/kiagnose/internal/reporter/reporter.go
@@ -21,6 +21,7 @@ package reporter
 
 import (
 	"errors"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +33,7 @@ import (
 )
 
 const (
+	SucceededKey           = "status.succeeded"
 	StartTimestampKey      = "status.startTimestamp"
 	CompletionTimestampKey = "status.completionTimestamp"
 )
@@ -75,6 +77,7 @@ func (r *Reporter) Report(statusData status.Status) error {
 
 	if !statusData.CompletionTimestamp.IsZero() {
 		r.configMap.Data[CompletionTimestampKey] = statusData.CompletionTimestamp.Format(time.RFC3339)
+		r.configMap.Data[SucceededKey] = strconv.FormatBool(statusData.Succeeded)
 	}
 
 	updatedConfigMap, err := configmap.Update(r.client.CoreV1(), r.configMap)

--- a/kiagnose/internal/reporter/reporter_test.go
+++ b/kiagnose/internal/reporter/reporter_test.go
@@ -75,10 +75,14 @@ func TestReportShouldSucceed(t *testing.T) {
 		setup()
 
 		assert.NoError(t, reporterUnderTest.Report(checkupStatus))
+
+		checkupStatus.CompletionTimestamp = checkupStatus.StartTimestamp.Add(time.Minute)
+
 		assert.NoError(t, reporterUnderTest.Report(checkupStatus))
 
 		expectedReportData := map[string]string{
-			reporter.StartTimestampKey: timestamp(checkupStatus.StartTimestamp),
+			reporter.StartTimestampKey:      timestamp(checkupStatus.StartTimestamp),
+			reporter.CompletionTimestampKey: timestamp(checkupStatus.CompletionTimestamp),
 		}
 
 		assert.Equal(t,

--- a/kiagnose/internal/reporter/reporter_test.go
+++ b/kiagnose/internal/reporter/reporter_test.go
@@ -45,8 +45,9 @@ const (
 
 func TestReportShouldSucceed(t *testing.T) {
 	type successTestCase struct {
-		description string
-		succeeded   bool
+		description   string
+		succeeded     bool
+		failureReason string
 	}
 
 	var (
@@ -79,12 +80,14 @@ func TestReportShouldSucceed(t *testing.T) {
 
 	testCases := []successTestCase{
 		{
-			description: "on checkup successful completion",
-			succeeded:   true,
+			description:   "on checkup successful completion",
+			succeeded:     true,
+			failureReason: "",
 		},
 		{
-			description: "on checkup failed completion",
-			succeeded:   false,
+			description:   "on checkup failed completion",
+			succeeded:     false,
+			failureReason: "some reason",
 		},
 	}
 
@@ -95,6 +98,7 @@ func TestReportShouldSucceed(t *testing.T) {
 			assert.NoError(t, reporterUnderTest.Report(checkupStatus))
 
 			checkupStatus.Succeeded = testCase.succeeded
+			checkupStatus.FailureReason = testCase.failureReason
 			checkupStatus.CompletionTimestamp = checkupStatus.StartTimestamp.Add(time.Minute)
 
 			assert.NoError(t, reporterUnderTest.Report(checkupStatus))
@@ -102,6 +106,7 @@ func TestReportShouldSucceed(t *testing.T) {
 			expectedReportData := map[string]string{
 				reporter.StartTimestampKey:      timestamp(checkupStatus.StartTimestamp),
 				reporter.SucceededKey:           strconv.FormatBool(checkupStatus.Succeeded),
+				reporter.FailureReasonKey:       checkupStatus.FailureReason,
 				reporter.CompletionTimestampKey: timestamp(checkupStatus.CompletionTimestamp),
 			}
 

--- a/kiagnose/internal/reporter/reporter_test.go
+++ b/kiagnose/internal/reporter/reporter_test.go
@@ -1,0 +1,170 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package reporter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kiagnose/kiagnose/kiagnose/internal/config"
+	"github.com/kiagnose/kiagnose/kiagnose/internal/configmap"
+	"github.com/kiagnose/kiagnose/kiagnose/internal/reporter"
+	"github.com/kiagnose/kiagnose/kiagnose/internal/status"
+)
+
+const (
+	configMapNamespace = "kiagnose"
+	configMapName      = "checkup1"
+)
+
+func TestReportShouldSucceed(t *testing.T) {
+	var (
+		fakeClient        *fake.Clientset
+		reporterUnderTest *reporter.Reporter
+		checkupStatus     status.Status
+	)
+
+	setup := func() {
+		fakeClient = fake.NewSimpleClientset(newConfigMap(checkupSpecData()))
+		reporterUnderTest = reporter.New(fakeClient, configMapNamespace, configMapName)
+
+		checkupStatus = status.Status{StartTimestamp: time.Now()}
+	}
+
+	t.Run("on initial report", func(t *testing.T) {
+		setup()
+
+		assert.NoError(t, reporterUnderTest.Report(checkupStatus))
+
+		expectedReportData := map[string]string{
+			reporter.StartTimestampKey: timestamp(checkupStatus.StartTimestamp),
+		}
+
+		assert.Equal(t,
+			mergeMaps(checkupSpecData(), expectedReportData),
+			getCheckupData(t, fakeClient, configMapNamespace, configMapName),
+		)
+	})
+
+	t.Run("on final report", func(t *testing.T) {
+		setup()
+
+		assert.NoError(t, reporterUnderTest.Report(checkupStatus))
+		assert.NoError(t, reporterUnderTest.Report(checkupStatus))
+
+		expectedReportData := map[string]string{
+			reporter.StartTimestampKey: timestamp(checkupStatus.StartTimestamp),
+		}
+
+		assert.Equal(t,
+			mergeMaps(checkupSpecData(), expectedReportData),
+			getCheckupData(t, fakeClient, configMapNamespace, configMapName),
+		)
+	})
+}
+
+func TestReportShouldFail(t *testing.T) {
+	t.Run("when checkup spec is fetched with nil Data", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset(newConfigMap(nil))
+		reporterUnderTest := reporter.New(fakeClient, configMapNamespace, configMapName)
+
+		checkupStatus := status.Status{}
+
+		assert.ErrorIs(t, reporterUnderTest.Report(checkupStatus), reporter.ErrConfigMapDataIsNil)
+	})
+
+	t.Run("when checkup spec fails to be fetched for the first time", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset()
+		reporterUnderTest := reporter.New(fakeClient, configMapNamespace, configMapName)
+
+		checkupStatus := status.Status{}
+
+		assert.ErrorContains(t, reporterUnderTest.Report(checkupStatus), "not found")
+	})
+
+	t.Run("when checkup status fails to be updated", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset(newConfigMap(checkupSpecData()))
+		reporterUnderTest := reporter.New(fakeClient, configMapNamespace, configMapName)
+
+		checkupStatus := status.Status{}
+
+		assert.NoError(t, reporterUnderTest.Report(checkupStatus))
+
+		injectFailureToAccessCheckupData(t, fakeClient, configMapNamespace, configMapName)
+
+		assert.ErrorContains(t, reporterUnderTest.Report(checkupStatus), "not found")
+	})
+}
+
+func checkupSpecData() map[string]string {
+	const (
+		testImageValue   = "mycheckup:v0.1.0"
+		testTimeoutValue = "1m"
+	)
+
+	return map[string]string{config.ImageKey: testImageValue, config.TimeoutKey: testTimeoutValue}
+}
+
+func newConfigMap(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: configMapNamespace,
+		},
+		Data: data,
+	}
+}
+
+func mergeMaps(map1, map2 map[string]string) map[string]string {
+	resultMap := map[string]string{}
+
+	for k, v := range map1 {
+		resultMap[k] = v
+	}
+
+	for k, v := range map2 {
+		resultMap[k] = v
+	}
+
+	return resultMap
+}
+
+func timestamp(t time.Time) string {
+	return t.Format(time.RFC3339)
+}
+
+func getCheckupData(t *testing.T, client kubernetes.Interface, configMapNamespace, configMapName string) map[string]string {
+	configMap, err := configmap.Get(client.CoreV1(), configMapNamespace, configMapName)
+	assert.NoError(t, err)
+
+	return configMap.Data
+}
+
+func injectFailureToAccessCheckupData(t *testing.T, client kubernetes.Interface, configMapNamespace, configMapName string) {
+	assert.NoError(t, client.CoreV1().ConfigMaps(configMapNamespace).Delete(context.Background(), configMapName, metav1.DeleteOptions{}))
+}

--- a/kiagnose/internal/status/status.go
+++ b/kiagnose/internal/status/status.go
@@ -22,5 +22,6 @@ package status
 import "time"
 
 type Status struct {
-	StartTimestamp time.Time
+	StartTimestamp      time.Time
+	CompletionTimestamp time.Time
 }

--- a/kiagnose/internal/status/status.go
+++ b/kiagnose/internal/status/status.go
@@ -23,6 +23,7 @@ import "time"
 
 type Status struct {
 	Succeeded           bool
+	FailureReason       string
 	StartTimestamp      time.Time
 	CompletionTimestamp time.Time
 }

--- a/kiagnose/internal/status/status.go
+++ b/kiagnose/internal/status/status.go
@@ -22,6 +22,7 @@ package status
 import "time"
 
 type Status struct {
+	Succeeded           bool
 	StartTimestamp      time.Time
 	CompletionTimestamp time.Time
 }

--- a/kiagnose/internal/status/status.go
+++ b/kiagnose/internal/status/status.go
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package status
+
+import "time"
+
+type Status struct {
+	StartTimestamp time.Time
+}

--- a/kiagnose/mainflow.go
+++ b/kiagnose/mainflow.go
@@ -43,6 +43,6 @@ func Run(env map[string]string) error {
 		return err
 	}
 
-	l := launcher.New(checkup.New(c, checkupConfig), reporter.New())
+	l := launcher.New(checkup.New(c, checkupConfig), reporter.New(c, configMapNamespace, configMapName))
 	return l.Run()
 }


### PR DESCRIPTION
This PR adds basic reporting capability:
1. The `startTimestamp` and `completionTimestamp` are recorded and reported.
2. `succeeded` field is always reported as `false`.
3. `failureReason` field is always reported as `Failure: implement me`.