### PR TITLE
launcher: Report actual checkup status

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -243,11 +243,11 @@ func NewCheckupJob(name, namespaceName, serviceAccountName, image string, active
 // by deleting the Namespace and eventually all the objects inside it
 // https://kubernetes.io/docs/concepts/architecture/garbage-collection/#background-deletion
 func (c *Checkup) Setup() error {
-	const errMessage = "checkup setup failed"
+	const errPrefix = "setup"
 	var err error
 
 	if c.namespace, err = namespace.Create(c.client.CoreV1(), c.namespace); err != nil {
-		return fmt.Errorf("%s: %v", errMessage, err)
+		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 	defer func() {
 		if err != nil {
@@ -256,23 +256,23 @@ func (c *Checkup) Setup() error {
 	}()
 
 	if c.serviceAccount, err = rbac.CreateServiceAccount(c.client.CoreV1(), c.serviceAccount); err != nil {
-		return fmt.Errorf("%s: %v", errMessage, err)
+		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
 	if c.resultConfigMap, err = configmap.Create(c.client.CoreV1(), c.resultConfigMap); err != nil {
-		return fmt.Errorf("%s: %v", errMessage, err)
+		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
 	if c.roles, err = rbac.CreateRoles(c.client.RbacV1(), c.roles); err != nil {
-		return fmt.Errorf("%s: %v", errMessage, err)
+		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
 	if c.roleBindings, err = rbac.CreateRoleBindings(c.client.RbacV1(), c.roleBindings); err != nil {
-		return fmt.Errorf("%s: %v", errMessage, err)
+		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
 	if c.clusterRoleBindings, err = rbac.CreateClusterRoleBindings(c.client.RbacV1(), c.clusterRoleBindings, c.teardownTimeout); err != nil {
-		return fmt.Errorf("%s: %v", errMessage, err)
+		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
 	return nil

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -279,14 +279,15 @@ func (c *Checkup) Setup() error {
 }
 
 func (c *Checkup) Run() error {
+	const errPrefix = "run"
 	var err error
 
 	if c.job, err = job.Create(c.client.BatchV1(), c.job); err != nil {
-		return err
+		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
 	if c.job, err = job.WaitForJobToFinish(c.client.BatchV1(), c.job, c.jobTimeout); err != nil {
-		return err
+		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
 	return nil

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -298,6 +298,7 @@ func (c *Checkup) SetTeardownTimeout(duration time.Duration) {
 }
 
 func (c *Checkup) Teardown() error {
+	const errPrefix = "teardown"
 	var errs []error
 
 	if err := rbac.DeleteClusterRoleBindings(c.client.RbacV1(), c.clusterRoleBindings, c.teardownTimeout); err != nil {
@@ -309,7 +310,7 @@ func (c *Checkup) Teardown() error {
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("failed to teardown checkup: %v", concentrateErrors(errs))
+		return fmt.Errorf("%s: %v", errPrefix, concentrateErrors(errs))
 	}
 
 	return nil

--- a/kiagnose/internal/launcher/launcher.go
+++ b/kiagnose/internal/launcher/launcher.go
@@ -56,8 +56,12 @@ func (l Launcher) Run() (runErr error) {
 	}
 
 	defer func() {
-		statusData.Succeeded = false
-		statusData.FailureReason = "Failure: implement me"
+		if runErr == nil {
+			statusData.Succeeded = true
+		} else {
+			statusData.FailureReason = runErr.Error()
+		}
+
 		statusData.CompletionTimestamp = time.Now()
 
 		if reportErr := l.reporter.Report(statusData); reportErr != nil {

--- a/kiagnose/internal/launcher/launcher_test.go
+++ b/kiagnose/internal/launcher/launcher_test.go
@@ -38,26 +38,8 @@ func TestLauncherRunsSuccessfully(t *testing.T) {
 	assert.NoError(t, testLauncher.Run())
 }
 
-func TestLauncherShould(t *testing.T) {
-	t.Run("fail when report on checkup start is failing", func(t *testing.T) {
-		testLauncher := launcher.New(
-			checkupStub{},
-			&reporterStub{reportErr: errorFailOnInitialReport},
-		)
-
-		assert.ErrorContains(t, testLauncher.Run(), errorFailOnInitialReport.Error())
-	})
-
-	t.Run("fail when report on checkup completion is failing", func(t *testing.T) {
-		testLauncher := launcher.New(
-			checkupStub{},
-			&reporterStub{reportErr: errorFailOnFinalReport},
-		)
-
-		assert.ErrorContains(t, testLauncher.Run(), errorFailOnFinalReport.Error())
-	})
-
-	t.Run("fail when setup is failing", func(t *testing.T) {
+func TestLauncherRunShouldFailWithReportWhen(t *testing.T) {
+	t.Run("setup is failing", func(t *testing.T) {
 		testLauncher := launcher.New(
 			checkupStub{failSetup: errorSetup},
 			&reporterStub{},
@@ -66,7 +48,45 @@ func TestLauncherShould(t *testing.T) {
 		assert.ErrorContains(t, testLauncher.Run(), errorSetup.Error())
 	})
 
-	t.Run("fail when setup and report on checkup completion are failing", func(t *testing.T) {
+	t.Run("run is failing", func(t *testing.T) {
+		testLauncher := launcher.New(
+			checkupStub{failRun: errorRun},
+			&reporterStub{},
+		)
+
+		assert.ErrorContains(t, testLauncher.Run(), errorRun.Error())
+	})
+
+	t.Run("teardown is failing", func(t *testing.T) {
+		testLauncher := launcher.New(
+			checkupStub{failTeardown: errorTeardown},
+			&reporterStub{},
+		)
+
+		assert.ErrorContains(t, testLauncher.Run(), errorTeardown.Error())
+	})
+}
+
+func TestLauncherRunShouldFailWithoutReportWhen(t *testing.T) {
+	t.Run("report on checkup start is failing", func(t *testing.T) {
+		testLauncher := launcher.New(
+			checkupStub{},
+			&reporterStub{reportErr: errorFailOnInitialReport},
+		)
+
+		assert.ErrorContains(t, testLauncher.Run(), errorFailOnInitialReport.Error())
+	})
+
+	t.Run("report on checkup completion is failing", func(t *testing.T) {
+		testLauncher := launcher.New(
+			checkupStub{},
+			&reporterStub{reportErr: errorFailOnFinalReport},
+		)
+
+		assert.ErrorContains(t, testLauncher.Run(), errorFailOnFinalReport.Error())
+	})
+
+	t.Run("setup and report on checkup completion are failing", func(t *testing.T) {
 		testLauncher := launcher.New(
 			checkupStub{failSetup: errorSetup},
 			&reporterStub{reportErr: errorFailOnFinalReport},
@@ -77,25 +97,7 @@ func TestLauncherShould(t *testing.T) {
 		assert.ErrorContains(t, err, errorFailOnFinalReport.Error())
 	})
 
-	t.Run("fail when run is failing", func(t *testing.T) {
-		testLauncher := launcher.New(
-			checkupStub{failRun: errorRun},
-			&reporterStub{},
-		)
-
-		assert.ErrorContains(t, testLauncher.Run(), errorRun.Error())
-	})
-
-	t.Run("fail when teardown is failing", func(t *testing.T) {
-		testLauncher := launcher.New(
-			checkupStub{failTeardown: errorTeardown},
-			&reporterStub{},
-		)
-
-		assert.ErrorContains(t, testLauncher.Run(), errorTeardown.Error())
-	})
-
-	t.Run("fail when run and report on checkup completion are failing", func(t *testing.T) {
+	t.Run("run and report on checkup completion are failing", func(t *testing.T) {
 		testLauncher := launcher.New(
 			checkupStub{failRun: errorRun},
 			&reporterStub{reportErr: errorFailOnFinalReport},
@@ -106,7 +108,7 @@ func TestLauncherShould(t *testing.T) {
 		assert.ErrorContains(t, err, errorFailOnFinalReport.Error())
 	})
 
-	t.Run("fail when teardown and report on checkup completion are failing", func(t *testing.T) {
+	t.Run("teardown and report on checkup completion are failing", func(t *testing.T) {
 		testLauncher := launcher.New(
 			checkupStub{failTeardown: errorTeardown},
 			&reporterStub{reportErr: errorFailOnFinalReport},
@@ -117,7 +119,7 @@ func TestLauncherShould(t *testing.T) {
 		assert.ErrorContains(t, err, errorFailOnFinalReport.Error())
 	})
 
-	t.Run("fail when run, teardown and report on checkup completion are failing", func(t *testing.T) {
+	t.Run("run, teardown and report on checkup completion are failing", func(t *testing.T) {
 		testLauncher := launcher.New(
 			checkupStub{failRun: errorRun, failTeardown: errorTeardown},
 			&reporterStub{reportErr: errorFailOnFinalReport},

--- a/kiagnose/internal/launcher/launcher_test.go
+++ b/kiagnose/internal/launcher/launcher_test.go
@@ -116,12 +116,14 @@ func TestLauncherRunShouldFailWithReportWhen(t *testing.T) {
 
 func TestLauncherRunShouldFailWithoutReportWhen(t *testing.T) {
 	t.Run("report on checkup start is failing", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset()
+
 		testLauncher := launcher.New(
 			checkupStub{},
-			&reporterStub{reportErr: errorFailOnInitialReport},
+			reporter.New(fakeClient, configMapNamespace, configMapName),
 		)
 
-		assert.ErrorContains(t, testLauncher.Run(), errorFailOnInitialReport.Error())
+		assert.ErrorContains(t, testLauncher.Run(), "not found")
 	})
 
 	t.Run("report on checkup completion is failing", func(t *testing.T) {

--- a/kiagnose/internal/launcher/launcher_test.go
+++ b/kiagnose/internal/launcher/launcher_test.go
@@ -29,16 +29,16 @@ import (
 	"github.com/kiagnose/kiagnose/kiagnose/internal/status"
 )
 
+func TestLauncherRunsSuccessfully(t *testing.T) {
+	testLauncher := launcher.New(
+		checkupStub{},
+		&reporterStub{},
+	)
+
+	assert.NoError(t, testLauncher.Run())
+}
+
 func TestLauncherShould(t *testing.T) {
-	t.Run("run successfully", func(t *testing.T) {
-		testLauncher := launcher.New(
-			checkupStub{},
-			&reporterStub{},
-		)
-
-		assert.NoError(t, testLauncher.Run())
-	})
-
 	t.Run("fail when report on checkup start is failing", func(t *testing.T) {
 		testLauncher := launcher.New(
 			checkupStub{},


### PR DESCRIPTION
Replace the hard codded report of "succeeded" and "failureReason" with an actual report.

The "succeeded" field is reported as "true" only when:
Checkup.Setup(), Checkup.Run() and Checkup.Teardown() are successfully completed.

At the moment, because the checkup results are not read, beyond the returned error from Checkup.Run(), there is not enough
data to declare the checkup as failed.

This PR also changes the launcher's tests to test the actual final report (in applicable test cases).

~~Depends on PR #45.~~