### PR TITLE
[WIP] config: Read from previously fetched ConfigMap

### DIFF
--- a/kiagnose/internal/config/config.go
+++ b/kiagnose/internal/config/config.go
@@ -28,7 +28,6 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/kiagnose/kiagnose/kiagnose/internal/configmap"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/rbac"
 )
 
@@ -40,15 +39,10 @@ type Config struct {
 	Roles        []*rbacv1.Role
 }
 
-func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMapName string) (*Config, error) {
-	configMap, err := configmap.Get(client.CoreV1(), configMapNamespace, configMapName)
-	if err != nil {
-		return nil, err
-	}
-
+func ReadFromConfigMap(client kubernetes.Interface, configMap *corev1.ConfigMap) (*Config, error) {
 	parser := newConfigMapParser(configMap.Data)
-	err = parser.Parse()
-	if err != nil {
+
+	if err := parser.Parse(); err != nil {
 		return nil, err
 	}
 

--- a/kiagnose/mainflow.go
+++ b/kiagnose/mainflow.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kiagnose/kiagnose/kiagnose/internal/checkup"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/client"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/config"
+	"github.com/kiagnose/kiagnose/kiagnose/internal/configmap"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/launcher"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/reporter"
 )
@@ -38,7 +39,12 @@ func Run(env map[string]string) error {
 		return err
 	}
 
-	checkupConfig, err := config.ReadFromConfigMap(c, configMapNamespace, configMapName)
+	configMap, err := configmap.Get(c.CoreV1(), configMapNamespace, configMapName)
+	if err != nil {
+		return err
+	}
+
+	checkupConfig, err := config.ReadFromConfigMap(c, configMap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Change mainflow to read raw ConfigMap object, so it could be passed
to config.ReadFromConfigMap(), and to the future Reporter.New().

This change reduces the amount of failure cases handled by config.

Signed-off-by: Orel Misan <omisan@redhat.com>