### PR TITLE
reporter: Report checkup results

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kiagnose/kiagnose/kiagnose/internal/config"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/configmap"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/rbac"
+	"github.com/kiagnose/kiagnose/kiagnose/internal/results"
 )
 
 type client interface {
@@ -291,6 +292,10 @@ func (c *Checkup) Run() error {
 	}
 
 	return nil
+}
+
+func (c *Checkup) Results() (results.Results, error) {
+	return results.ReadFromConfigMap(c.client.CoreV1(), c.resultConfigMap.Namespace, c.resultConfigMap.Name)
 }
 
 func (c *Checkup) SetTeardownTimeout(duration time.Duration) {

--- a/kiagnose/internal/launcher/launcher.go
+++ b/kiagnose/internal/launcher/launcher.go
@@ -92,6 +92,7 @@ func (l Launcher) Run() (runErr error) {
 		} else {
 			statusData.Succeeded = checkupResults.Succeeded
 			statusData.FailureReason = checkupResults.FailureReason
+			statusData.Results = checkupResults.Results
 		}
 
 		if teardownErr := l.checkup.Teardown(); teardownErr != nil {

--- a/kiagnose/internal/launcher/launcher.go
+++ b/kiagnose/internal/launcher/launcher.go
@@ -35,7 +35,7 @@ type workload interface {
 }
 
 type reporter interface {
-	Report(status.Status) error
+	Report(*status.Status) error
 }
 
 type Launcher struct {
@@ -53,7 +53,7 @@ func New(checkup workload, reporter reporter) Launcher {
 func (l Launcher) Run() (runErr error) {
 	statusData := status.Status{StartTimestamp: time.Now()}
 
-	if err := l.reporter.Report(statusData); err != nil {
+	if err := l.reporter.Report(&statusData); err != nil {
 		return err
 	}
 
@@ -69,7 +69,7 @@ func (l Launcher) Run() (runErr error) {
 
 		statusData.CompletionTimestamp = time.Now()
 
-		if reportErr := l.reporter.Report(statusData); reportErr != nil {
+		if reportErr := l.reporter.Report(&statusData); reportErr != nil {
 			if runErr != nil {
 				runErr = fmt.Errorf("%v, %v", runErr, reportErr)
 			} else {

--- a/kiagnose/internal/launcher/launcher_test.go
+++ b/kiagnose/internal/launcher/launcher_test.go
@@ -46,6 +46,11 @@ const (
 )
 
 func TestLauncherRunWithResultsWhen(t *testing.T) {
+	const (
+		resultsKey1   = "result1"
+		resultsValue1 = "result 1 value"
+	)
+
 	type resultsTestCase struct {
 		description  string
 		inputResults results.Results
@@ -53,12 +58,18 @@ func TestLauncherRunWithResultsWhen(t *testing.T) {
 
 	testCases := []resultsTestCase{
 		{
-			description:  "checkup runs successfully",
-			inputResults: results.Results{Succeeded: true},
+			description: "checkup runs successfully",
+			inputResults: results.Results{
+				Succeeded: true,
+				Results:   map[string]string{resultsKey1: resultsValue1},
+			},
 		},
 		{
-			description:  "checkup fails",
-			inputResults: results.Results{FailureReason: "some reason"},
+			description: "checkup fails",
+			inputResults: results.Results{
+				FailureReason: "some reason",
+				Results:       map[string]string{resultsKey1: resultsValue1},
+			},
 		},
 	}
 
@@ -79,6 +90,11 @@ func TestLauncherRunWithResultsWhen(t *testing.T) {
 			expectedData := checkupSpecData()
 			expectedData[reporter.SucceededKey] = strconv.FormatBool(testCase.inputResults.Succeeded)
 			expectedData[reporter.FailureReasonKey] = testCase.inputResults.FailureReason
+
+			for k, v := range testCase.inputResults.Results {
+				expectedData[reporter.ResultsPrefix+k] = v
+			}
+
 			zeroTimestamps(expectedData)
 
 			assert.Equal(t, expectedData, actualCheckupData)

--- a/kiagnose/internal/launcher/launcher_test.go
+++ b/kiagnose/internal/launcher/launcher_test.go
@@ -249,7 +249,7 @@ type reporterStub struct {
 	reportCount int
 }
 
-func (r *reporterStub) Report(_ status.Status) error {
+func (r *reporterStub) Report(_ *status.Status) error {
 	r.reportCount++
 	if r.reportCount > 2 {
 		panic("Report was called more than twice")

--- a/kiagnose/internal/reporter/reporter.go
+++ b/kiagnose/internal/reporter/reporter.go
@@ -35,6 +35,7 @@ import (
 const (
 	SucceededKey           = "status.succeeded"
 	FailureReasonKey       = "status.failureReason"
+	ResultsPrefix          = "status.result."
 	StartTimestampKey      = "status.startTimestamp"
 	CompletionTimestampKey = "status.completionTimestamp"
 )
@@ -80,6 +81,10 @@ func (r *Reporter) Report(statusData *status.Status) error {
 		r.configMap.Data[CompletionTimestampKey] = statusData.CompletionTimestamp.Format(time.RFC3339)
 		r.configMap.Data[SucceededKey] = strconv.FormatBool(statusData.Succeeded)
 		r.configMap.Data[FailureReasonKey] = statusData.FailureReason
+	}
+
+	for k, v := range statusData.Results {
+		r.configMap.Data[ResultsPrefix+k] = v
 	}
 
 	updatedConfigMap, err := configmap.Update(r.client.CoreV1(), r.configMap)

--- a/kiagnose/internal/reporter/reporter.go
+++ b/kiagnose/internal/reporter/reporter.go
@@ -58,7 +58,7 @@ func New(client kubernetes.Interface, configMapNamespace, configMapName string) 
 	}
 }
 
-func (r *Reporter) Report(statusData status.Status) error {
+func (r *Reporter) Report(statusData *status.Status) error {
 	if r.configMap.Data == nil {
 		configMap, err := configmap.Get(r.client.CoreV1(), r.configMap.Namespace, r.configMap.Name)
 		if err != nil {

--- a/kiagnose/internal/reporter/reporter_test.go
+++ b/kiagnose/internal/reporter/reporter_test.go
@@ -66,7 +66,7 @@ func TestReportShouldSucceed(t *testing.T) {
 	t.Run("on initial report", func(t *testing.T) {
 		setup()
 
-		assert.NoError(t, reporterUnderTest.Report(checkupStatus))
+		assert.NoError(t, reporterUnderTest.Report(&checkupStatus))
 
 		expectedReportData := map[string]string{
 			reporter.StartTimestampKey: timestamp(checkupStatus.StartTimestamp),
@@ -95,13 +95,13 @@ func TestReportShouldSucceed(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			setup()
 
-			assert.NoError(t, reporterUnderTest.Report(checkupStatus))
+			assert.NoError(t, reporterUnderTest.Report(&checkupStatus))
 
 			checkupStatus.Succeeded = testCase.succeeded
 			checkupStatus.FailureReason = testCase.failureReason
 			checkupStatus.CompletionTimestamp = checkupStatus.StartTimestamp.Add(time.Minute)
 
-			assert.NoError(t, reporterUnderTest.Report(checkupStatus))
+			assert.NoError(t, reporterUnderTest.Report(&checkupStatus))
 
 			expectedReportData := map[string]string{
 				reporter.StartTimestampKey:      timestamp(checkupStatus.StartTimestamp),
@@ -125,7 +125,7 @@ func TestReportShouldFail(t *testing.T) {
 
 		checkupStatus := status.Status{}
 
-		assert.ErrorIs(t, reporterUnderTest.Report(checkupStatus), reporter.ErrConfigMapDataIsNil)
+		assert.ErrorIs(t, reporterUnderTest.Report(&checkupStatus), reporter.ErrConfigMapDataIsNil)
 	})
 
 	t.Run("when checkup spec fails to be fetched for the first time", func(t *testing.T) {
@@ -134,7 +134,7 @@ func TestReportShouldFail(t *testing.T) {
 
 		checkupStatus := status.Status{}
 
-		assert.ErrorContains(t, reporterUnderTest.Report(checkupStatus), "not found")
+		assert.ErrorContains(t, reporterUnderTest.Report(&checkupStatus), "not found")
 	})
 
 	t.Run("when checkup status fails to be updated", func(t *testing.T) {
@@ -143,11 +143,11 @@ func TestReportShouldFail(t *testing.T) {
 
 		checkupStatus := status.Status{}
 
-		assert.NoError(t, reporterUnderTest.Report(checkupStatus))
+		assert.NoError(t, reporterUnderTest.Report(&checkupStatus))
 
 		injectFailureToAccessCheckupData(t, fakeClient, configMapNamespace, configMapName)
 
-		assert.ErrorContains(t, reporterUnderTest.Report(checkupStatus), "not found")
+		assert.ErrorContains(t, reporterUnderTest.Report(&checkupStatus), "not found")
 	})
 }
 

--- a/kiagnose/internal/results/results.go
+++ b/kiagnose/internal/results/results.go
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package results
+
+import (
+	"errors"
+	"strconv"
+
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/kiagnose/kiagnose/kiagnose/internal/configmap"
+)
+
+const (
+	SucceededKey     = "status.succeeded"
+	FailureReasonKey = "status.failureReason"
+)
+
+var (
+	ErrConfigMapDataIsNil        = errors.New("results: ConfigMap Data is nil")
+	ErrSucceededFieldMissing     = errors.New("results: succeeded field is missing")
+	ErrSucceededFieldIllegal     = errors.New("results: succeeded field is illegal")
+	ErrFailureReasonFieldMissing = errors.New("results: failureReason field is missing")
+)
+
+type Results struct {
+	Succeeded     bool
+	FailureReason string
+}
+
+func ReadFromConfigMap(client corev1client.CoreV1Interface, configMapNamespace, configMapName string) (Results, error) {
+	resultsData := Results{}
+
+	configMap, err := configmap.Get(client, configMapNamespace, configMapName)
+	if err != nil {
+		return resultsData, err
+	}
+
+	if configMap.Data == nil {
+		return resultsData, ErrConfigMapDataIsNil
+	}
+
+	if resultsData.Succeeded, err = parseSucceededField(configMap.Data); err != nil {
+		return resultsData, err
+	}
+
+	if resultsData.FailureReason, err = parseFailureReasonField(configMap.Data); err != nil {
+		return resultsData, err
+	}
+
+	return resultsData, nil
+}
+
+func parseSucceededField(data map[string]string) (bool, error) {
+	rawSucceededField, exists := data[SucceededKey]
+	if !exists {
+		return false, ErrSucceededFieldMissing
+	}
+
+	succeeded, err := strconv.ParseBool(rawSucceededField)
+	if err != nil {
+		return false, ErrSucceededFieldIllegal
+	}
+
+	return succeeded, nil
+}
+
+func parseFailureReasonField(data map[string]string) (string, error) {
+	failureReason, exists := data[FailureReasonKey]
+	if !exists {
+		return "", ErrFailureReasonFieldMissing
+	}
+
+	return failureReason, nil
+}

--- a/kiagnose/internal/results/results_test.go
+++ b/kiagnose/internal/results/results_test.go
@@ -1,0 +1,150 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package results_test
+
+import (
+	"strconv"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	assert "github.com/stretchr/testify/require"
+
+	"github.com/kiagnose/kiagnose/kiagnose/internal/results"
+)
+
+const (
+	configMapNamespace = "kiagnose"
+	configMapName      = "checkup1"
+)
+
+func TestReadResultsShouldSucceedWhen(t *testing.T) {
+	type successTestCase struct {
+		description     string
+		input           map[string]string
+		expectedResults results.Results
+	}
+
+	const (
+		emptyFailureReason = ""
+		testFailureReason  = "some reason"
+	)
+
+	testCases := []successTestCase{
+		{
+			description: "checkup succeeds",
+			input: map[string]string{
+				results.SucceededKey:     strconv.FormatBool(true),
+				results.FailureReasonKey: emptyFailureReason,
+			},
+			expectedResults: results.Results{
+				Succeeded:     true,
+				FailureReason: emptyFailureReason,
+			},
+		},
+		{
+			description: "checkup fails",
+			input: map[string]string{
+				results.SucceededKey:     strconv.FormatBool(false),
+				results.FailureReasonKey: testFailureReason,
+			},
+			expectedResults: results.Results{
+				Succeeded:     false,
+				FailureReason: testFailureReason,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(newConfigMap(testCase.input))
+
+			actualResults, err := results.ReadFromConfigMap(fakeClient.CoreV1(), configMapNamespace, configMapName)
+			assert.NoError(t, err)
+
+			assert.Equal(t, testCase.expectedResults, actualResults)
+		})
+	}
+}
+
+func TestReadResultsShouldFailWhen(t *testing.T) {
+	t.Run("failing to fetch results", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset()
+
+		_, err := results.ReadFromConfigMap(fakeClient.CoreV1(), configMapNamespace, configMapName)
+
+		assert.ErrorContains(t, err, "not found")
+	})
+
+	type failureTestCase struct {
+		description   string
+		input         map[string]string
+		expectedError error
+	}
+
+	testCases := []failureTestCase{
+		{
+			description:   "results are fetched with nil Data",
+			input:         nil,
+			expectedError: results.ErrConfigMapDataIsNil,
+		},
+		{
+			description:   "succeeded field is missing",
+			input:         map[string]string{},
+			expectedError: results.ErrSucceededFieldMissing,
+		},
+		{
+			description: "succeeded field is illegal",
+			input: map[string]string{
+				results.SucceededKey: "not a boolean",
+			},
+			expectedError: results.ErrSucceededFieldIllegal,
+		},
+		{
+			description: "failureReason field is missing",
+			input: map[string]string{
+				results.SucceededKey: strconv.FormatBool(false),
+			},
+			expectedError: results.ErrFailureReasonFieldMissing,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(newConfigMap(testCase.input))
+
+			_, err := results.ReadFromConfigMap(fakeClient.CoreV1(), configMapNamespace, configMapName)
+
+			assert.ErrorIs(t, err, testCase.expectedError)
+		})
+	}
+}
+
+func newConfigMap(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: configMapNamespace,
+		},
+		Data: data,
+	}
+}

--- a/kiagnose/internal/results/results_test.go
+++ b/kiagnose/internal/results/results_test.go
@@ -47,6 +47,12 @@ func TestReadResultsShouldSucceedWhen(t *testing.T) {
 	const (
 		emptyFailureReason = ""
 		testFailureReason  = "some reason"
+		resultsKey1        = "result1"
+		resultsValue1      = "result 1 value"
+		resultsKey2        = "result2"
+		resultsValue2      = "result 2 value"
+		resultsKey3        = "result3"
+		resultsValue3      = ""
 	)
 
 	testCases := []successTestCase{
@@ -59,6 +65,26 @@ func TestReadResultsShouldSucceedWhen(t *testing.T) {
 			expectedResults: results.Results{
 				Succeeded:     true,
 				FailureReason: emptyFailureReason,
+				Results:       map[string]string{},
+			},
+		},
+		{
+			description: "checkup succeeds with results",
+			input: map[string]string{
+				results.SucceededKey:                strconv.FormatBool(true),
+				results.FailureReasonKey:            emptyFailureReason,
+				results.ResultsPrefix + resultsKey1: resultsValue1,
+				results.ResultsPrefix + resultsKey2: resultsValue2,
+				results.ResultsPrefix + resultsKey3: resultsValue3,
+			},
+			expectedResults: results.Results{
+				Succeeded:     true,
+				FailureReason: emptyFailureReason,
+				Results: map[string]string{
+					resultsKey1: resultsValue1,
+					resultsKey2: resultsValue2,
+					resultsKey3: resultsValue3,
+				},
 			},
 		},
 		{
@@ -70,6 +96,26 @@ func TestReadResultsShouldSucceedWhen(t *testing.T) {
 			expectedResults: results.Results{
 				Succeeded:     false,
 				FailureReason: testFailureReason,
+				Results:       map[string]string{},
+			},
+		},
+		{
+			description: "checkup fails with results",
+			input: map[string]string{
+				results.SucceededKey:                strconv.FormatBool(false),
+				results.FailureReasonKey:            testFailureReason,
+				results.ResultsPrefix + resultsKey1: resultsValue1,
+				results.ResultsPrefix + resultsKey2: resultsValue2,
+				results.ResultsPrefix + resultsKey3: resultsValue3,
+			},
+			expectedResults: results.Results{
+				Succeeded:     false,
+				FailureReason: testFailureReason,
+				Results: map[string]string{
+					resultsKey1: resultsValue1,
+					resultsKey2: resultsValue2,
+					resultsKey3: resultsValue3,
+				},
 			},
 		},
 	}

--- a/kiagnose/internal/status/status.go
+++ b/kiagnose/internal/status/status.go
@@ -24,6 +24,7 @@ import "time"
 type Status struct {
 	Succeeded           bool
 	FailureReason       string
+	Results             map[string]string
 	StartTimestamp      time.Time
 	CompletionTimestamp time.Time
 }


### PR DESCRIPTION
Until now, the results reported by the checkup hasn't been read by the framework.

Read and report the checkup's reported results:
1. `succeeded`.
2. `failureReason`.
3. Checkup custom results (optional).

The "succeeded" field value is a "true", when no errors had occurred in the framework or in the checkup.

The `failureReason` field is a concatenation of:
1. The value reported by the checkup (if exists).
2. `Checkup.Run()` error (if occurred).
3. `Checkup.Results()` error (if occurred).
4. `Checkup.Teardown()` error (if occurred).

~~Depends on PR #46.~~