### PR TITLE
linter: Increase hugeParam threshold size (to 1024)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,9 @@ linters-settings:
       - octalLiteral
       - whyNoLint
       - wrapperFunc
+    settings:
+      hugeParam:
+        sizeThreshold: 1024
   gocyclo:
     min-complexity: 15
   goimports:


### PR DESCRIPTION
The hugeParam linter warns against passing a large amount of data to a
function, causing a large copy.

The cost of a copy is not always obvious.
There are several reasons against converting data to a pointer:
- Readability: From the caller stand of view, passing a pointer may be
  interpreted as if the function is going to mutate the data.
- The compiler may optimize the machine code such that there is no copy.
- Passing a pointer may imply usage of the heap, which is also costly
  (compare to the stack).

Increasing the threshold value higher, gives more control to
the code author to decide what fits as a pointer and what not.