### PR TITLE
Do not use pointers when not needed

### DIFF
--- a/kiagnose/internal/launcher/launcher.go
+++ b/kiagnose/internal/launcher/launcher.go
@@ -35,7 +35,7 @@ type workload interface {
 }
 
 type reporter interface {
-	Report(*status.Status) error
+	Report(status.Status) error
 }
 
 type Launcher struct {
@@ -53,7 +53,7 @@ func New(checkup workload, reporter reporter) Launcher {
 func (l Launcher) Run() (runErr error) {
 	statusData := status.Status{StartTimestamp: time.Now()}
 
-	if err := l.reporter.Report(&statusData); err != nil {
+	if err := l.reporter.Report(statusData); err != nil {
 		return err
 	}
 
@@ -69,7 +69,7 @@ func (l Launcher) Run() (runErr error) {
 
 		statusData.CompletionTimestamp = time.Now()
 
-		if reportErr := l.reporter.Report(&statusData); reportErr != nil {
+		if reportErr := l.reporter.Report(statusData); reportErr != nil {
 			if runErr != nil {
 				runErr = fmt.Errorf("%v, %v", runErr, reportErr)
 			} else {

--- a/kiagnose/internal/launcher/launcher_test.go
+++ b/kiagnose/internal/launcher/launcher_test.go
@@ -265,7 +265,7 @@ type reporterStub struct {
 	reportCount int
 }
 
-func (r *reporterStub) Report(_ *status.Status) error {
+func (r *reporterStub) Report(_ status.Status) error {
 	r.reportCount++
 	if r.reportCount > 2 {
 		panic("Report was called more than twice")

--- a/kiagnose/internal/launcher/launcher_test.go
+++ b/kiagnose/internal/launcher/launcher_test.go
@@ -78,7 +78,7 @@ func TestLauncherRunWithResultsWhen(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(newConfigMap(checkupSpecData()))
 
 			testLauncher := launcher.New(
-				&checkupStub{results: testCase.inputResults},
+				checkupStub{results: testCase.inputResults},
 				reporter.New(fakeClient, configMapNamespace, configMapName),
 			)
 
@@ -137,7 +137,7 @@ func TestLauncherRunShouldFailWithReportWhen(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(newConfigMap(checkupSpecData()))
 
 			testLauncher := launcher.New(
-				&testCase.inputCheckup,
+				testCase.inputCheckup,
 				reporter.New(fakeClient, configMapNamespace, configMapName),
 			)
 
@@ -161,7 +161,7 @@ func TestLauncherRunShouldFailWithoutReportWhen(t *testing.T) {
 		fakeClient := fake.NewSimpleClientset()
 
 		testLauncher := launcher.New(
-			&checkupStub{},
+			checkupStub{},
 			reporter.New(fakeClient, configMapNamespace, configMapName),
 		)
 
@@ -170,7 +170,7 @@ func TestLauncherRunShouldFailWithoutReportWhen(t *testing.T) {
 
 	t.Run("report on checkup completion is failing", func(t *testing.T) {
 		testLauncher := launcher.New(
-			&checkupStub{},
+			checkupStub{},
 			&reporterStub{reportErr: errorFailOnFinalReport},
 		)
 
@@ -179,7 +179,7 @@ func TestLauncherRunShouldFailWithoutReportWhen(t *testing.T) {
 
 	t.Run("setup and report on checkup completion are failing", func(t *testing.T) {
 		testLauncher := launcher.New(
-			&checkupStub{failSetup: errorSetup},
+			checkupStub{failSetup: errorSetup},
 			&reporterStub{reportErr: errorFailOnFinalReport},
 		)
 
@@ -190,7 +190,7 @@ func TestLauncherRunShouldFailWithoutReportWhen(t *testing.T) {
 
 	t.Run("run and report on checkup completion are failing", func(t *testing.T) {
 		testLauncher := launcher.New(
-			&checkupStub{failRun: errorRun},
+			checkupStub{failRun: errorRun},
 			&reporterStub{reportErr: errorFailOnFinalReport},
 		)
 
@@ -201,7 +201,7 @@ func TestLauncherRunShouldFailWithoutReportWhen(t *testing.T) {
 
 	t.Run("teardown and report on checkup completion are failing", func(t *testing.T) {
 		testLauncher := launcher.New(
-			&checkupStub{failTeardown: errorTeardown},
+			checkupStub{failTeardown: errorTeardown},
 			&reporterStub{reportErr: errorFailOnFinalReport},
 		)
 
@@ -212,7 +212,7 @@ func TestLauncherRunShouldFailWithoutReportWhen(t *testing.T) {
 
 	t.Run("run, teardown and report on checkup completion are failing", func(t *testing.T) {
 		testLauncher := launcher.New(
-			&checkupStub{failRun: errorRun, failTeardown: errorTeardown},
+			checkupStub{failRun: errorRun, failTeardown: errorTeardown},
 			&reporterStub{reportErr: errorFailOnFinalReport},
 		)
 
@@ -240,15 +240,15 @@ type checkupStub struct {
 	results      results.Results
 }
 
-func (s *checkupStub) Setup() error {
+func (s checkupStub) Setup() error {
 	return s.failSetup
 }
 
-func (s *checkupStub) Run() error {
+func (s checkupStub) Run() error {
 	return s.failRun
 }
 
-func (s *checkupStub) Results() (results.Results, error) {
+func (s checkupStub) Results() (results.Results, error) {
 	if s.failResults != nil {
 		return s.results, s.failResults
 	}
@@ -256,7 +256,7 @@ func (s *checkupStub) Results() (results.Results, error) {
 	return s.results, nil
 }
 
-func (s *checkupStub) Teardown() error {
+func (s checkupStub) Teardown() error {
 	return s.failTeardown
 }
 

--- a/kiagnose/internal/reporter/reporter.go
+++ b/kiagnose/internal/reporter/reporter.go
@@ -59,7 +59,7 @@ func New(client kubernetes.Interface, configMapNamespace, configMapName string) 
 	}
 }
 
-func (r *Reporter) Report(statusData *status.Status) error {
+func (r *Reporter) Report(statusData status.Status) error {
 	if r.configMap.Data == nil {
 		configMap, err := configmap.Get(r.client.CoreV1(), r.configMap.Namespace, r.configMap.Name)
 		if err != nil {

--- a/kiagnose/internal/reporter/reporter_test.go
+++ b/kiagnose/internal/reporter/reporter_test.go
@@ -66,7 +66,7 @@ func TestReportShouldSucceed(t *testing.T) {
 	t.Run("on initial report", func(t *testing.T) {
 		setup()
 
-		assert.NoError(t, reporterUnderTest.Report(&checkupStatus))
+		assert.NoError(t, reporterUnderTest.Report(checkupStatus))
 
 		expectedReportData := map[string]string{
 			reporter.StartTimestampKey: timestamp(checkupStatus.StartTimestamp),
@@ -95,13 +95,13 @@ func TestReportShouldSucceed(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			setup()
 
-			assert.NoError(t, reporterUnderTest.Report(&checkupStatus))
+			assert.NoError(t, reporterUnderTest.Report(checkupStatus))
 
 			checkupStatus.Succeeded = testCase.succeeded
 			checkupStatus.FailureReason = testCase.failureReason
 			checkupStatus.CompletionTimestamp = checkupStatus.StartTimestamp.Add(time.Minute)
 
-			assert.NoError(t, reporterUnderTest.Report(&checkupStatus))
+			assert.NoError(t, reporterUnderTest.Report(checkupStatus))
 
 			expectedReportData := map[string]string{
 				reporter.StartTimestampKey:      timestamp(checkupStatus.StartTimestamp),
@@ -125,7 +125,7 @@ func TestReportShouldFail(t *testing.T) {
 
 		checkupStatus := status.Status{}
 
-		assert.ErrorIs(t, reporterUnderTest.Report(&checkupStatus), reporter.ErrConfigMapDataIsNil)
+		assert.ErrorIs(t, reporterUnderTest.Report(checkupStatus), reporter.ErrConfigMapDataIsNil)
 	})
 
 	t.Run("when checkup spec fails to be fetched for the first time", func(t *testing.T) {
@@ -134,7 +134,7 @@ func TestReportShouldFail(t *testing.T) {
 
 		checkupStatus := status.Status{}
 
-		assert.ErrorContains(t, reporterUnderTest.Report(&checkupStatus), "not found")
+		assert.ErrorContains(t, reporterUnderTest.Report(checkupStatus), "not found")
 	})
 
 	t.Run("when checkup status fails to be updated", func(t *testing.T) {
@@ -143,11 +143,11 @@ func TestReportShouldFail(t *testing.T) {
 
 		checkupStatus := status.Status{}
 
-		assert.NoError(t, reporterUnderTest.Report(&checkupStatus))
+		assert.NoError(t, reporterUnderTest.Report(checkupStatus))
 
 		injectFailureToAccessCheckupData(t, fakeClient, configMapNamespace, configMapName)
 
-		assert.ErrorContains(t, reporterUnderTest.Report(&checkupStatus), "not found")
+		assert.ErrorContains(t, reporterUnderTest.Report(checkupStatus), "not found")
 	})
 }
 


### PR DESCRIPTION
When function receivers or arguments are defined as pointers, beyond the
functional need it also exposes an intent.

When reading the code, an expression like `foo(&myvar)` has the
potential to be interpreted as: "foo is mutating myvar".
On the other hand, seeing `foo(myvar)` is more likely to express to the
reader that the intent is to keep the variable immutable.

The PR reverts the move to pointers due to a linter requirement [1].

[1] https://github.com/kiagnose/kiagnose/pull/48

~Depends on #51 (for this one to pass the checks).~