### PR TITLE
configmap: Use default K8s clientset

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -288,7 +288,7 @@ func (c *Checkup) Run() error {
 }
 
 func (c *Checkup) Results() (results.Results, error) {
-	return results.ReadFromConfigMap(c.client.CoreV1(), c.resultConfigMap.Namespace, c.resultConfigMap.Name)
+	return results.ReadFromConfigMap(c.client, c.resultConfigMap.Namespace, c.resultConfigMap.Name)
 }
 
 func (c *Checkup) SetTeardownTimeout(duration time.Duration) {

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -253,7 +253,7 @@ func (c *Checkup) Setup() error {
 		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
-	if c.resultConfigMap, err = configmap.Create(c.client.CoreV1(), c.resultConfigMap); err != nil {
+	if c.resultConfigMap, err = configmap.Create(c.client, c.resultConfigMap); err != nil {
 		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -29,9 +29,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
+
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/kiagnose/kiagnose/kiagnose/internal/checkup/job"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/checkup/namespace"
@@ -41,14 +40,8 @@ import (
 	"github.com/kiagnose/kiagnose/kiagnose/internal/results"
 )
 
-type client interface {
-	CoreV1() corev1client.CoreV1Interface
-	RbacV1() rbacv1client.RbacV1Interface
-	BatchV1() batchv1client.BatchV1Interface
-}
-
 type Checkup struct {
-	client              client
+	client              kubernetes.Interface
 	teardownTimeout     time.Duration
 	namespace           *corev1.Namespace
 	serviceAccount      *corev1.ServiceAccount
@@ -71,7 +64,7 @@ const (
 	ResultsConfigMapNameEnvVarNamespace = "RESULT_CONFIGMAP_NAMESPACE"
 )
 
-func New(c client, checkupConfig *config.Config) *Checkup {
+func New(c kubernetes.Interface, checkupConfig *config.Config) *Checkup {
 	checkupRoles := []*rbacv1.Role{NewConfigMapWriterRole(ResultsConfigMapWriterRoleName, NamespaceName, ResultsConfigMapName)}
 
 	subject := newServiceAccountSubject(ServiceAccountName, NamespaceName)

--- a/kiagnose/internal/config/config.go
+++ b/kiagnose/internal/config/config.go
@@ -41,7 +41,7 @@ type Config struct {
 }
 
 func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMapName string) (*Config, error) {
-	configMap, err := configmap.Get(client.CoreV1(), configMapNamespace, configMapName)
+	configMap, err := configmap.Get(client, configMapNamespace, configMapName)
 	if err != nil {
 		return nil, err
 	}

--- a/kiagnose/internal/configmap/configmap.go
+++ b/kiagnose/internal/configmap/configmap.go
@@ -39,8 +39,8 @@ func Create(client kubernetes.Interface, cm *corev1.ConfigMap) (*corev1.ConfigMa
 	return createdConfigMap, nil
 }
 
-func Get(client corev1client.CoreV1Interface, namespace, name string) (*corev1.ConfigMap, error) {
-	return client.ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
+func Get(client kubernetes.Interface, namespace, name string) (*corev1.ConfigMap, error) {
+	return client.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
 }
 
 func Update(client corev1client.CoreV1Interface, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {

--- a/kiagnose/internal/configmap/configmap.go
+++ b/kiagnose/internal/configmap/configmap.go
@@ -26,10 +26,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"k8s.io/client-go/kubernetes"
 )
 
-func Create(client corev1client.CoreV1Interface, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	createdConfigMap, err := client.ConfigMaps(cm.Namespace).Create(context.Background(), cm, metav1.CreateOptions{})
+func Create(client kubernetes.Interface, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	createdConfigMap, err := client.CoreV1().ConfigMaps(cm.Namespace).Create(context.Background(), cm, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/kiagnose/internal/configmap/configmap.go
+++ b/kiagnose/internal/configmap/configmap.go
@@ -25,8 +25,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -43,6 +41,6 @@ func Get(client kubernetes.Interface, namespace, name string) (*corev1.ConfigMap
 	return client.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
 }
 
-func Update(client corev1client.CoreV1Interface, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	return client.ConfigMaps(configMap.Namespace).Update(context.Background(), configMap, metav1.UpdateOptions{})
+func Update(client kubernetes.Interface, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return client.CoreV1().ConfigMaps(configMap.Namespace).Update(context.Background(), configMap, metav1.UpdateOptions{})
 }

--- a/kiagnose/internal/launcher/launcher_test.go
+++ b/kiagnose/internal/launcher/launcher_test.go
@@ -299,7 +299,7 @@ func newConfigMap(data map[string]string) *corev1.ConfigMap {
 }
 
 func getCheckupData(t *testing.T, client kubernetes.Interface, configMapNamespace, configMapName string) map[string]string {
-	configMap, err := configmap.Get(client.CoreV1(), configMapNamespace, configMapName)
+	configMap, err := configmap.Get(client, configMapNamespace, configMapName)
 	assert.NoError(t, err)
 
 	return configMap.Data

--- a/kiagnose/internal/reporter/reporter.go
+++ b/kiagnose/internal/reporter/reporter.go
@@ -61,7 +61,7 @@ func New(client kubernetes.Interface, configMapNamespace, configMapName string) 
 
 func (r *Reporter) Report(statusData *status.Status) error {
 	if r.configMap.Data == nil {
-		configMap, err := configmap.Get(r.client.CoreV1(), r.configMap.Namespace, r.configMap.Name)
+		configMap, err := configmap.Get(r.client, r.configMap.Namespace, r.configMap.Name)
 		if err != nil {
 			return err
 		}

--- a/kiagnose/internal/reporter/reporter.go
+++ b/kiagnose/internal/reporter/reporter.go
@@ -87,7 +87,7 @@ func (r *Reporter) Report(statusData *status.Status) error {
 		r.configMap.Data[ResultsPrefix+k] = v
 	}
 
-	updatedConfigMap, err := configmap.Update(r.client.CoreV1(), r.configMap)
+	updatedConfigMap, err := configmap.Update(r.client, r.configMap)
 	if err != nil {
 		return err
 	}

--- a/kiagnose/internal/reporter/reporter_test.go
+++ b/kiagnose/internal/reporter/reporter_test.go
@@ -189,7 +189,7 @@ func timestamp(t time.Time) string {
 }
 
 func getCheckupData(t *testing.T, client kubernetes.Interface, configMapNamespace, configMapName string) map[string]string {
-	configMap, err := configmap.Get(client.CoreV1(), configMapNamespace, configMapName)
+	configMap, err := configmap.Get(client, configMapNamespace, configMapName)
 	assert.NoError(t, err)
 
 	return configMap.Data

--- a/kiagnose/internal/results/results.go
+++ b/kiagnose/internal/results/results.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"strings"
 
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/kiagnose/kiagnose/kiagnose/internal/configmap"
 )
@@ -48,7 +48,7 @@ type Results struct {
 	Results       map[string]string
 }
 
-func ReadFromConfigMap(client corev1client.CoreV1Interface, configMapNamespace, configMapName string) (Results, error) {
+func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMapName string) (Results, error) {
 	resultsData := Results{}
 
 	configMap, err := configmap.Get(client, configMapNamespace, configMapName)

--- a/kiagnose/internal/results/results_test.go
+++ b/kiagnose/internal/results/results_test.go
@@ -124,7 +124,7 @@ func TestReadResultsShouldSucceedWhen(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(newConfigMap(testCase.input))
 
-			actualResults, err := results.ReadFromConfigMap(fakeClient.CoreV1(), configMapNamespace, configMapName)
+			actualResults, err := results.ReadFromConfigMap(fakeClient, configMapNamespace, configMapName)
 			assert.NoError(t, err)
 
 			assert.Equal(t, testCase.expectedResults, actualResults)
@@ -136,7 +136,7 @@ func TestReadResultsShouldFailWhen(t *testing.T) {
 	t.Run("failing to fetch results", func(t *testing.T) {
 		fakeClient := fake.NewSimpleClientset()
 
-		_, err := results.ReadFromConfigMap(fakeClient.CoreV1(), configMapNamespace, configMapName)
+		_, err := results.ReadFromConfigMap(fakeClient, configMapNamespace, configMapName)
 
 		assert.ErrorContains(t, err, "not found")
 	})
@@ -178,7 +178,7 @@ func TestReadResultsShouldFailWhen(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(newConfigMap(testCase.input))
 
-			_, err := results.ReadFromConfigMap(fakeClient.CoreV1(), configMapNamespace, configMapName)
+			_, err := results.ReadFromConfigMap(fakeClient, configMapNamespace, configMapName)
 
 			assert.ErrorIs(t, err, testCase.expectedError)
 		})


### PR DESCRIPTION
Until now, Checkup held as a state, a custom "client" interface which was a small subset of the default "kubernetes.Interface"
client set.

The custom client interface was set up because we didn't know in advanced if K8s fake client will be suitable for our needs.

The custom client interface was forcing its users to use a specific client version (for example CoreV1) instead of having
a choice to select a client from the default client set.

This had a system-wide affect, affecting all functions that were called from Checkup, and using the client.

Because the "configmap" package was affected, other packages were affected as well.

Holding a client from type "kubernetes.Interface", allows its users a choice to select the most suitable client.