### PR TITLE
kubevirt-vm-latency: Spin up VMs 

### DIFF
--- a/checkups/kubevirt-vm-latency/cmd/environment.go
+++ b/checkups/kubevirt-vm-latency/cmd/environment.go
@@ -19,7 +19,10 @@
 
 package main
 
-import "strings"
+import (
+	"os"
+	"strings"
+)
 
 func envToMap(rawEnv []string) map[string]string {
 	const requiredElementsCount = 2
@@ -36,4 +39,15 @@ func envToMap(rawEnv []string) map[string]string {
 	}
 
 	return env
+}
+
+func readNamespaceFile() (string, error) {
+	const namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+	ns, err := os.ReadFile(namespaceFile)
+	if err != nil {
+		return "", err
+	}
+
+	return string(ns), nil
 }

--- a/checkups/kubevirt-vm-latency/cmd/main.go
+++ b/checkups/kubevirt-vm-latency/cmd/main.go
@@ -27,8 +27,15 @@ import (
 )
 
 func main() {
+	const errMessagePrefix = "Kubevirt VM latency checkup failed"
 	env := envToMap(os.Environ())
-	if err := vmlatency.Run(env); err != nil {
-		log.Fatalf("Kubevirt VM latency checkup failed: %v\n", err)
+
+	workingNamespace, err := readNamespaceFile()
+	if err != nil {
+		log.Fatalf("%s: %v\n", errMessagePrefix, err)
+	}
+
+	if err := vmlatency.Run(env, workingNamespace); err != nil {
+		log.Fatalf("%s: %v\n", errMessagePrefix, err)
 	}
 }

--- a/checkups/kubevirt-vm-latency/go.mod
+++ b/checkups/kubevirt-vm-latency/go.mod
@@ -2,7 +2,12 @@ module github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency
 
 go 1.17
 
-require github.com/stretchr/testify v1.7.1
+require (
+	github.com/stretchr/testify v1.7.1
+	k8s.io/api v0.23.5
+	kubevirt.io/api v0.0.0-20220430221853-33880526e414
+	sigs.k8s.io/yaml v1.3.0
+)
 
 // Kubevirt client-go dependencies
 require (
@@ -50,16 +55,13 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.23.5 // indirect
 	k8s.io/apiextensions-apiserver v0.23.1 // indirect
 	k8s.io/client-go v12.0.0+incompatible // indirect
 	k8s.io/klog/v2 v2.40.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
-	kubevirt.io/api v0.0.0-20220430221853-33880526e414 // indirect
 	kubevirt.io/containerized-data-importer-api v1.47.0 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/checkups/kubevirt-vm-latency/manifests/clusterroles.yaml
+++ b/checkups/kubevirt-vm-latency/manifests/clusterroles.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubevirt-vmis-manager
+rules:
+- apiGroups: ["kubevirt.io"]
+  resources: ["virtualmachineinstances"]
+  verbs: ["get", "create", "delete"]

--- a/checkups/kubevirt-vm-latency/manifests/dev/kubevirt-vm-latency-checkup.yaml
+++ b/checkups/kubevirt-vm-latency/manifests/dev/kubevirt-vm-latency-checkup.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt-vm-latency-checkup
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-vm-latency-checkup-results
+  namespace: kubevirt-vm-latency-checkup
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-vm-latency-checkup
+  namespace: kubevirt-vm-latency-checkup
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: configmap-patcher
+  namespace: kubevirt-vm-latency-checkup
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "get", "patch" ]
+    resourceNames: ["kubevirt-vm-latency-checkup-results"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: configmap-patcher-kubevirt-vm-latency-checkup-sa
+  namespace: kubevirt-vm-latency-checkup
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-vm-latency-checkup-sa
+    namespace: kubevirt-vm-latency-checkup
+roleRef:
+  kind: Role
+  name: configmap-patcher
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubevirt-vmis-manager
+rules:
+- apiGroups: ["kubevirt.io"]
+  resources: ["virtualmachineinstances"]
+  verbs: ["get", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-vmis-manager
+subjects:
+- kind: ServiceAccount
+  name: kubevirt-vm-latency-checkup
+  namespace: kubevirt-vm-latency-checkup
+roleRef:
+  kind: ClusterRole
+  name: kubevirt-vmis-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kubevirt-vm-latency-checkup
+  namespace: kubevirt-vm-latency-checkup
+spec:
+  activeDeadlineSeconds: 60
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: kubevirt-vm-latency-checkup
+      containers:
+        - name: vmlatency
+          image: quay.io/kiagnose/kubevirt-vm-latency:devel
+          env:
+            - name: RESULT_CONFIGMAP_NAMESPACE
+              value: "kubevirt-vm-latency-checkup"
+            - name: RESULT_CONFIGMAP_NAME
+              value: "kubevirt-vm-latency-checkup-results"
+            - name: NETWORK_ATTACHMENT_DEFINITION_NAME
+              value: "sriov-network"
+            - name: NETWORK_ATTACHMENT_DEFINITION_NAMESPACE
+              value: "default"
+            - name: SAMPLE_DURATION_SECONDS
+              value: "30"
+            - name: MAX_DESIRED_LATENCY_MILLISECONDS
+              value: "100"
+            - name: SOURCE_NODE
+              value: ""
+            - name: TARGET_NODE
+              value: ""

--- a/checkups/kubevirt-vm-latency/manifests/kubevirt-vm-latency-checkup.yaml
+++ b/checkups/kubevirt-vm-latency/manifests/kubevirt-vm-latency-checkup.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-vm-latency-checkup-config
+  namespace: kiagnose
+data:
+  spec.image: quay.io/kiagnose/kubevirt-vm-latency-checkup:main
+  spec.timeout: 5m
+  spec.clusterRoles: |
+    kubevirt-vmis-manager
+  spec.param.network_attachment_definition_namespace: "default"
+  spec.param.network_attachment_definition_name: "sriov-network"
+  spec.param.max_desired_latency_milliseconds: "10"
+  spec.param.sample_duration_seconds: "5"
+  spec.param.source_node: "sriov-worker"
+  spec.param.target_node: "sriov-worker2"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kubevirt-vm-latency-checkup1
+  namespace: kiagnose
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccount: kiagnose
+      restartPolicy: Never
+      containers:
+        - name: framework
+          image: quay.io/kiagnose/kiagnose:main
+          imagePullPolicy: Always
+          env:
+            - name: CONFIGMAP_NAMESPACE
+              value: kiagnose
+            - name: CONFIGMAP_NAME
+              value: kubevirt-vm-latency-checkup-config

--- a/checkups/kubevirt-vm-latency/manifests/sriov-network-attachment-definition.yaml
+++ b/checkups/kubevirt-vm-latency/manifests/sriov-network-attachment-definition.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-network
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: kubevirt.io/sriov_net
+spec:
+  config: |
+    {
+      "cniVersion":"0.3.1",
+      "name":"sriov-network",
+      "type":"sriov",
+      "vlan":0,
+      "spoofchk":"on",
+      "trust":"off",
+      "vlanQoS":0,
+      "link_state":"enable",
+      "ipam":{}
+    }

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -28,13 +28,18 @@ import (
 )
 
 type checkup struct {
-	client  *client.Client
-	params  config.CheckupParameters
-	results status.Results
+	client    *client.Client
+	namespace string
+	params    config.CheckupParameters
+	results   status.Results
 }
 
-func New(c *client.Client, params config.CheckupParameters) *checkup {
-	return &checkup{client: c, params: params}
+func New(c *client.Client, namespace string, params config.CheckupParameters) *checkup {
+	return &checkup{
+		client:    c,
+		namespace: namespace,
+		params:    params,
+	}
 }
 
 func (c *checkup) Preflight() error {

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package checkup_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/require"
+
+	kvcorev1 "kubevirt.io/api/core/v1"
+
+	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/checkup"
+	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/config"
+)
+
+const (
+	testNamespace             = "default"
+	testNetAttachDefName      = "blue-net"
+	testSampleDurationSeconds = 1
+	testTimeout               = time.Nanosecond
+)
+
+func TestCheckupSetupShouldFailWhen(t *testing.T) {
+	t.Run("failed to create a VM", func(t *testing.T) {
+		expectedError := errors.New("vmi create test error")
+		testCheckup := checkup.New(
+			clientStub{failCreateVmi: expectedError},
+			testNamespace,
+			newTestsCheckupParameters())
+
+		assert.NoError(t, testCheckup.Preflight())
+		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedError.Error())
+	})
+
+	t.Run("VMs were not ready before timeout expiration", func(t *testing.T) {
+		expectedError := errors.New("timed out")
+		testCheckup := checkup.New(
+			clientStub{failGetVmi: expectedError},
+			testNamespace,
+			newTestsCheckupParameters())
+
+		testCtx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		assert.NoError(t, testCheckup.Preflight())
+		assert.ErrorContains(t, testCheckup.Setup(testCtx), expectedError.Error())
+	})
+}
+
+func newTestsCheckupParameters() config.CheckupParameters {
+	return config.CheckupParameters{
+		NetworkAttachmentDefinitionName:      testNetAttachDefName,
+		NetworkAttachmentDefinitionNamespace: testNamespace,
+		TargetNodeName:                       "",
+		SourceNodeName:                       "",
+		SampleDurationSeconds:                testSampleDurationSeconds,
+		DesiredMaxLatencyMilliseconds:        0,
+	}
+}
+
+type clientStub struct {
+	failGetVmi    error
+	failCreateVmi error
+}
+
+func (c clientStub) GetVirtualMachineInstance(_, _ string) (*kvcorev1.VirtualMachineInstance, error) {
+	return nil, c.failGetVmi
+}
+
+func (c clientStub) CreateVirtualMachineInstance(_ string, _ *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error) {
+	return nil, c.failCreateVmi
+}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
@@ -23,6 +23,7 @@ import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kvcorev1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 )
 
@@ -49,4 +50,14 @@ func (c *Client) UpdateConfigMap(namespace, name string, date map[string]string)
 	}
 
 	return nil
+}
+
+func (c *Client) GetVirtualMachineInstance(namespace, name string) (*kvcorev1.VirtualMachineInstance, error) {
+	return c.KubevirtClient.VirtualMachineInstance(namespace).Get(name, &metav1.GetOptions{})
+}
+
+func (c *Client) CreateVirtualMachineInstance(
+	namespace string,
+	vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error) {
+	return c.KubevirtClient.VirtualMachineInstance(namespace).Create(vmi)
 }

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
@@ -61,3 +61,7 @@ func (c *Client) CreateVirtualMachineInstance(
 	vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error) {
 	return c.KubevirtClient.VirtualMachineInstance(namespace).Create(vmi)
 }
+
+func (c *Client) DeleteVirtualMachineInstance(namespace, name string) error {
+	return c.KubevirtClient.VirtualMachineInstance(namespace).Delete(name, &metav1.DeleteOptions{})
+}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher.go
@@ -20,6 +20,7 @@
 package launcher
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -28,9 +29,9 @@ import (
 
 type checkup interface {
 	Preflight() error
-	Setup() error
+	Setup(ctx context.Context) error
 	Run() error
-	Teardown() error
+	Teardown(ctx context.Context) error
 	Results() status.Results
 }
 
@@ -66,13 +67,13 @@ func (l launcher) Run() (runErr error) {
 		return err
 	}
 
-	if err := l.checkup.Setup(); err != nil {
+	if err := l.checkup.Setup(context.Background()); err != nil {
 		runStatus.FailureReason = append(runStatus.FailureReason, err.Error())
 		return err
 	}
 
 	defer func() {
-		if err := l.checkup.Teardown(); err != nil {
+		if err := l.checkup.Teardown(context.Background()); err != nil {
 			runStatus.FailureReason = append(runStatus.FailureReason, err.Error())
 		}
 	}()

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestLauncherShouldFail(t *testing.T) {
-	testLauncher := launcher.New(checkup.New(&client.Client{}, config.CheckupParameters{}), reporterStub{})
+	testLauncher := launcher.New(checkup.New(&client.Client{}, "", config.CheckupParameters{}), reporterStub{})
 
 	assert.Equal(t, testLauncher.Run(), errors.New("run: not implemented"))
 }

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/cloudinit.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/cloudinit.go
@@ -1,0 +1,132 @@
+/*
+ *
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+// Package vmi source: https://github.com/kubevirt/kubevirt/blob/v0.53.0/tests/libnet
+package vmi
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/yaml"
+)
+
+type cloudInitNetworkData struct {
+	Version   int                           `json:"version"`
+	Ethernets map[string]cloudInitInterface `json:"ethernets,omitempty"`
+}
+
+type cloudInitInterface struct {
+	name           string
+	AcceptRA       *bool                `json:"accept-ra,omitempty"`
+	Addresses      []string             `json:"addresses,omitempty"`
+	DHCP4          *bool                `json:"dhcp4,omitempty"`
+	DHCP6          *bool                `json:"dhcp6,omitempty"`
+	DHCPIdentifier string               `json:"dhcp-identifier,omitempty"` // "duid" or  "mac"
+	Gateway4       string               `json:"gateway4,omitempty"`
+	Gateway6       string               `json:"gateway6,omitempty"`
+	Nameservers    cloudInitNameservers `json:"nameservers,omitempty"`
+	MACAddress     string               `json:"macaddress,omitempty"`
+	Match          cloudInitMatch       `json:"match,omitempty"`
+	MTU            int                  `json:"mtu,omitempty"`
+	Routes         []cloudInitRoute     `json:"routes,omitempty"`
+	SetName        string               `json:"set-name,omitempty"`
+}
+
+type cloudInitNameservers struct {
+	Search    []string `json:"search,omitempty"`
+	Addresses []string `json:"addresses,omitempty"`
+}
+
+type cloudInitMatch struct {
+	Name       string `json:"name,omitempty"`
+	MACAddress string `json:"macaddress,omitempty"`
+	Driver     string `json:"driver,omitempty"`
+}
+
+type cloudInitRoute struct {
+	From   string `json:"from,omitempty"`
+	OnLink *bool  `json:"on-link,omitempty"`
+	Scope  string `json:"scope,omitempty"`
+	Table  *int   `json:"table,omitempty"`
+	To     string `json:"to,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Via    string `json:"via,omitempty"`
+	Metric *int   `json:"metric,omitempty"`
+}
+
+type networkDataOption func(*cloudInitNetworkData) error
+type networkDataInterfaceOption func(*cloudInitInterface) error
+
+func NewNetworkData(options ...networkDataOption) (string, error) {
+	networkData := cloudInitNetworkData{
+		Version: 2,
+	}
+
+	for _, option := range options {
+		err := option(&networkData)
+		if err != nil {
+			return "", fmt.Errorf("failed defining network data when running options: %w", err)
+		}
+	}
+
+	nd, err := yaml.Marshal(&networkData)
+	if err != nil {
+		return "", err
+	}
+
+	return string(nd), nil
+}
+
+func WithEthernet(name string, options ...networkDataInterfaceOption) networkDataOption {
+	return func(networkData *cloudInitNetworkData) error {
+		if networkData.Ethernets == nil {
+			networkData.Ethernets = map[string]cloudInitInterface{}
+		}
+
+		networkDataInterface := cloudInitInterface{name: name}
+
+		for _, option := range options {
+			err := option(&networkDataInterface)
+			if err != nil {
+				return fmt.Errorf("failed defining network data ethernet device when running options: %w", err)
+			}
+		}
+
+		networkData.Ethernets[name] = networkDataInterface
+		return nil
+	}
+}
+
+func WithAddresses(addresses ...string) networkDataInterfaceOption {
+	return func(networkDataInterface *cloudInitInterface) error {
+		networkDataInterface.Addresses = append(networkDataInterface.Addresses, addresses...)
+		return nil
+	}
+}
+
+func WithMatchingMAC(macAddress string) networkDataInterfaceOption {
+	return func(networkDataInterface *cloudInitInterface) error {
+		networkDataInterface.Match = cloudInitMatch{
+			MACAddress: macAddress,
+		}
+		networkDataInterface.SetName = networkDataInterface.name
+		return nil
+	}
+}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package vmi
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	k8scorev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	kvcorev1 "kubevirt.io/api/core/v1"
+)
+
+type KubevirtVmisClient interface {
+	GetVirtualMachineInstance(namespace, name string) (*kvcorev1.VirtualMachineInstance, error)
+	CreateVirtualMachineInstance(namespace string, vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error)
+}
+
+func Start(c KubevirtVmisClient, namespace string, vmi *kvcorev1.VirtualMachineInstance) error {
+	log.Printf("starting VMI %s/%s..", namespace, vmi.Name)
+	if _, err := c.CreateVirtualMachineInstance(namespace, vmi); err != nil {
+		return fmt.Errorf("failed to start VMI %s/%s: %v", vmi.Namespace, vmi.Name, err)
+	}
+	return nil
+}
+
+func WaitUntilReady(ctx context.Context, c KubevirtVmisClient, namespace, name string) error {
+	log.Printf("waiting for VMI %s/%s to be ready..\n", namespace, name)
+
+	if err := waitForVmiCondition(ctx, c, namespace, name, kvcorev1.VirtualMachineInstanceAgentConnected); err != nil {
+		return fmt.Errorf("VMI %s/%s was not ready on time: %v", namespace, name, err)
+	}
+
+	return nil
+}
+
+func waitForVmiCondition(ctx context.Context, c KubevirtVmisClient, namespace, name string,
+	conditionType kvcorev1.VirtualMachineInstanceConditionType) error {
+	conditionFn := func(ctx context.Context) (bool, error) {
+		updatedVmi, err := c.GetVirtualMachineInstance(namespace, name)
+		if err != nil {
+			return false, nil
+		}
+		for _, condition := range updatedVmi.Status.Conditions {
+			if condition.Type == conditionType && condition.Status == k8scorev1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	const interval = time.Second * 5
+	if err := wait.PollImmediateUntilWithContext(ctx, interval, conditionFn); err != nil {
+		return fmt.Errorf("failed to wait for VMI %s/%s condition %s: %v", namespace, name, conditionType, err)
+	}
+
+	return nil
+}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
@@ -1,0 +1,209 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+// Package vmi source https://github.com/kubevirt/kubevirt/tree/v0.53.0/tests/libvmi
+package vmi
+
+import (
+	k8scorev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kvcorev1 "kubevirt.io/api/core/v1"
+)
+
+// Option represents an action that enables an option.
+type Option func(vmi *kvcorev1.VirtualMachineInstance)
+
+// newBaseVmi instantiates a new VMI configuration,
+// building its properties based on the specified With* options.
+func newBaseVmi(name string, opts ...Option) *kvcorev1.VirtualMachineInstance {
+	vmi := &kvcorev1.VirtualMachineInstance{
+		TypeMeta: k8smetav1.TypeMeta{
+			Kind:       kvcorev1.VirtualMachineInstanceGroupVersionKind.Kind,
+			APIVersion: kvcorev1.GroupVersion.String(),
+		},
+		ObjectMeta: k8smetav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: kvcorev1.VirtualMachineInstanceSpec{},
+	}
+
+	for _, f := range opts {
+		f(vmi)
+	}
+
+	return vmi
+}
+
+// withTerminationGracePeriodSecond sets TerminationGracePeriodSecond.
+func withTerminationGracePeriodSecond(duration int64) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.TerminationGracePeriodSeconds = &duration
+	}
+}
+
+// WithNodeSelector ensures that the VMI gets scheduled on the specified node.
+func WithNodeSelector(nodeName string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if vmi.Spec.NodeSelector == nil {
+			vmi.Spec.NodeSelector = map[string]string{}
+		}
+		vmi.Spec.NodeSelector[k8scorev1.LabelHostname] = nodeName
+	}
+}
+
+// withResourceMemory specifies the vmi memory resource.
+func withResourceMemory(value string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Resources.Requests = k8scorev1.ResourceList{
+			k8scorev1.ResourceMemory: resource.MustParse(value),
+		}
+	}
+}
+
+// withRng adds 'rng' to the vmi devices.
+func withRng() Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.Rng = &kvcorev1.Rng{}
+	}
+}
+
+// WithMultusNetwork adds network with Multus network source.
+func WithMultusNetwork(networkName, netAttachDefName string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Networks = append(vmi.Spec.Networks, multusNetwork(networkName, netAttachDefName))
+	}
+}
+
+func multusNetwork(name, netAttachDefName string) kvcorev1.Network {
+	return kvcorev1.Network{
+		Name: name,
+		NetworkSource: kvcorev1.NetworkSource{
+			Multus: &kvcorev1.MultusNetwork{
+				NetworkName: netAttachDefName,
+			},
+		},
+	}
+}
+
+// WithCloudInitNoCloudNetworkData adds cloud-init no-cloud network data.
+func WithCloudInitNoCloudNetworkData(networkData string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		const volumeName = "cloudinit"
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newCloudinitVolumeWithNetworkData(volumeName, networkData))
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, newDisk(volumeName))
+	}
+}
+
+func newCloudinitVolumeWithNetworkData(name, networkData string) kvcorev1.Volume {
+	return kvcorev1.Volume{
+		Name: name,
+		VolumeSource: kvcorev1.VolumeSource{
+			CloudInitNoCloud: &kvcorev1.CloudInitNoCloudSource{
+				NetworkData: networkData,
+			},
+		},
+	}
+}
+
+func newDisk(name string) kvcorev1.Disk {
+	return kvcorev1.Disk{
+		Name: name,
+		DiskDevice: kvcorev1.DiskDevice{
+			Disk: &kvcorev1.DiskTarget{
+				Bus: kvcorev1.DiskBusVirtio,
+			},
+		},
+	}
+}
+
+func withContainerDiskImage(name string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		diskName := "disk0"
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, newDisk(diskName))
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newContainerDiskVolume(diskName, name))
+	}
+}
+
+func newContainerDiskVolume(name, image string) kvcorev1.Volume {
+	return kvcorev1.Volume{
+		Name: name,
+		VolumeSource: kvcorev1.VolumeSource{
+			ContainerDisk: &kvcorev1.ContainerDiskSource{
+				Image: image,
+			},
+		},
+	}
+}
+
+// WithInterface adds an interface.
+func WithInterface(iface kvcorev1.Interface) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, iface)
+	}
+}
+
+// interfaceOption represents an action that enables an option on a VMI interface.
+type interfaceOption func(vmi *kvcorev1.Interface)
+
+// NewInterface instantiates a new VMI interface configuration,
+// building its properties based on the specified With* options.
+func NewInterface(name string, opts ...interfaceOption) kvcorev1.Interface {
+	iface := &kvcorev1.Interface{Name: name}
+
+	for _, f := range opts {
+		f(iface)
+	}
+
+	return *iface
+}
+
+// WithMacAddress set the interface with custom MAC address.
+func WithMacAddress(macAddress string) interfaceOption {
+	return func(iface *kvcorev1.Interface) {
+		iface.MacAddress = macAddress
+	}
+}
+
+// WithSriovBinding set the interface with SR-IOV binding method.
+func WithSriovBinding() interfaceOption {
+	return func(iface *kvcorev1.Interface) {
+		iface.InterfaceBindingMethod = kvcorev1.InterfaceBindingMethod{
+			SRIOV: &kvcorev1.InterfaceSRIOV{},
+		}
+	}
+}
+
+func NewAlpine(name string, opts ...Option) *kvcorev1.VirtualMachineInstance {
+	const (
+		memory                                     = "128Mi"
+		alpineContainerDiskImage                   = "quay.io/kubevirt/alpine-with-test-tooling-container-disk:v0.53.0"
+		defaultTerminationGracePeriodSeconds int64 = 5
+	)
+	latencyCheckOpts := []Option{
+		withContainerDiskImage(alpineContainerDiskImage),
+		withTerminationGracePeriodSecond(defaultTerminationGracePeriodSeconds),
+		withResourceMemory(memory),
+		withRng(),
+	}
+	latencyCheckOpts = append(latencyCheckOpts, opts...)
+
+	return newBaseVmi(name, latencyCheckOpts...)
+}

--- a/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
@@ -27,7 +27,7 @@ import (
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/reporter"
 )
 
-func Run(env map[string]string) error {
+func Run(env map[string]string, namespace string) error {
 	c, err := client.New()
 	if err != nil {
 		return err
@@ -38,6 +38,9 @@ func Run(env map[string]string) error {
 		return err
 	}
 
-	l := launcher.New(checkup.New(c, cfg.CheckupParameters), reporter.New(c, cfg.ResultsConfigMapNamespace, cfg.ResultsConfigMapName))
+	l := launcher.New(
+		checkup.New(c, namespace, cfg.CheckupParameters),
+		reporter.New(c, cfg.ResultsConfigMapNamespace, cfg.ResultsConfigMapName),
+	)
 	return l.Run()
 }


### PR DESCRIPTION
With this PR changes the Kubevirt VM lantecy checkup will spin up two SR-IOV VMs inside its working namespace.
Each VM is configured with custom MAC address and static IP address using cloudinit.

On teadown, is will do best effort to delete the VMs, in case a once of the VMs fail to delete 
or did was not disposed on time it wont fail immediately. 
Instead it will try delete next VM, when finished it will return an error with the failing VMs and errors.

In order to deploy the checkup, apply the manifests under 'checkups/kubevirt-vm-latency/manifests':
from checkups/kubevirt-vm-latency:
```
$ kubectl apply -f ./manifests/sriov-network-attachment-definition.yaml
$ kubectl apply -f ./manifests/clusterroles.yaml
$ kubectl apply -f ./manifests/kubevirt-vm-latency-checkup.yaml
```

View results:
`$ kubectl get configmap kubevirt-vm-latency-checkup-config -n kiagnose -o yaml
`
Cleanup:
```
$ kubectl delete -f ./manifests/kubevirt-vm-latency-checkup.yaml
$ kubectl delete -f ./manifests/clusterroles.yaml
$ kubectl delete -f ./manifests/sriov-network-attachment-definition.yaml
```

Its possible to run the checkup directly without the framework (e.g: for development)
by applying the manifests under 'checkups/kubevirt-vm-latency/manifests/dev':
from checkups/kubevirt-vm-latency:
`$ kubectl apply -f ./manifests/dev/kubevirt-vm-latency-checkup.yaml
`
Ciew results:
`$ kubectl get configmap kubevirt-vm-latency-checkup-results -n kubevirt-vm-latency-checkup -o yaml
`
Clean up:
`
$ kubectl delete -f ./manifests/dev/kubevirt-vm-latency-checkup.yaml
`

This PR does not address bridged networks, currently only SR-IOV networks are supported.
