### PR TITLE
checkup, job: Use default K8s client-set

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -244,7 +244,7 @@ func (c *Checkup) Run() error {
 	const errPrefix = "run"
 	var err error
 
-	if c.job, err = job.Create(c.client.BatchV1(), c.job); err != nil {
+	if c.job, err = job.Create(c.client, c.job); err != nil {
 		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -248,7 +248,7 @@ func (c *Checkup) Run() error {
 		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
-	if c.job, err = job.WaitForJobToFinish(c.client.BatchV1(), c.job, c.jobTimeout); err != nil {
+	if c.job, err = job.WaitForJobToFinish(c.client, c.job, c.jobTimeout); err != nil {
 		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 

--- a/kiagnose/internal/checkup/job/job.go
+++ b/kiagnose/internal/checkup/job/job.go
@@ -29,11 +29,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8swatch "k8s.io/apimachinery/pkg/watch"
+
+	"k8s.io/client-go/kubernetes"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 )
 
-func Create(client batchv1client.BatchV1Interface, job *batchv1.Job) (*batchv1.Job, error) {
-	job, err := client.Jobs(job.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
+func Create(client kubernetes.Interface, job *batchv1.Job) (*batchv1.Job, error) {
+	job, err := client.BatchV1().Jobs(job.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/kiagnose/internal/checkup/job/job.go
+++ b/kiagnose/internal/checkup/job/job.go
@@ -31,7 +31,6 @@ import (
 	k8swatch "k8s.io/apimachinery/pkg/watch"
 
 	"k8s.io/client-go/kubernetes"
-	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 )
 
 func Create(client kubernetes.Interface, job *batchv1.Job) (*batchv1.Job, error) {
@@ -43,13 +42,13 @@ func Create(client kubernetes.Interface, job *batchv1.Job) (*batchv1.Job, error)
 	return job, nil
 }
 
-func WaitForJobToFinish(client batchv1client.BatchV1Interface, job *batchv1.Job, timeout time.Duration) (*batchv1.Job, error) {
+func WaitForJobToFinish(client kubernetes.Interface, job *batchv1.Job, timeout time.Duration) (*batchv1.Job, error) {
 	const JobNameLabel = "job-name"
 
 	jobLabel := fmt.Sprintf("%s=%s", JobNameLabel, job.Name)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	jobWatcher, err := client.Jobs(job.Namespace).Watch(ctx, metav1.ListOptions{LabelSelector: jobLabel})
+	jobWatcher, err := client.BatchV1().Jobs(job.Namespace).Watch(ctx, metav1.ListOptions{LabelSelector: jobLabel})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Change the client type to default client-set (kubernetes.Interface) in functions belonging to the checkup.job package.

Because we are using K8s fake client as a stub, there is no need to use a client other than the default.

~~Depends on PR #54.~~