### PR TITLE
checkup, ServiceAccount: Use default K8s client-set

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -217,7 +217,7 @@ func (c *Checkup) Setup() error {
 		}
 	}()
 
-	if c.serviceAccount, err = serviceaccount.Create(c.client.CoreV1(), c.serviceAccount); err != nil {
+	if c.serviceAccount, err = serviceaccount.Create(c.client, c.serviceAccount); err != nil {
 		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 

--- a/kiagnose/internal/checkup/serviceaccount/serviceaccount.go
+++ b/kiagnose/internal/checkup/serviceaccount/serviceaccount.go
@@ -25,11 +25,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"k8s.io/client-go/kubernetes"
 )
 
-func Create(client corev1client.CoreV1Interface, sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-	createdSa, err := client.ServiceAccounts(sa.Namespace).Create(context.Background(), sa, metav1.CreateOptions{})
+func Create(client kubernetes.Interface, sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+	createdSa, err := client.CoreV1().ServiceAccounts(sa.Namespace).Create(context.Background(), sa, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Change the client type of `serviceaccount.Create()` to the default client-set (kubernetes.Interface).

Because we are using K8s fake client as a stub, there is no need to use a client other than the default.

~~Depends on PR #54.~~