### PR TITLE
checkup, serviceaccount: Move CreateServiceAccount()

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/kiagnose/kiagnose/kiagnose/internal/checkup/job"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/checkup/namespace"
+	"github.com/kiagnose/kiagnose/kiagnose/internal/checkup/serviceaccount"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/config"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/configmap"
 	"github.com/kiagnose/kiagnose/kiagnose/internal/rbac"
@@ -223,7 +224,7 @@ func (c *Checkup) Setup() error {
 		}
 	}()
 
-	if c.serviceAccount, err = rbac.CreateServiceAccount(c.client.CoreV1(), c.serviceAccount); err != nil {
+	if c.serviceAccount, err = serviceaccount.Create(c.client.CoreV1(), c.serviceAccount); err != nil {
 		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 

--- a/kiagnose/internal/checkup/serviceaccount/serviceaccount.go
+++ b/kiagnose/internal/checkup/serviceaccount/serviceaccount.go
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package serviceaccount
+
+import (
+	"context"
+	"log"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func Create(client corev1client.CoreV1Interface, sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+	createdSa, err := client.ServiceAccounts(sa.Namespace).Create(context.Background(), sa, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("ServiceAccount '%s/%s' successfully created", sa.Namespace, sa.Name)
+
+	return createdSa, nil
+}

--- a/kiagnose/internal/rbac/rbac.go
+++ b/kiagnose/internal/rbac/rbac.go
@@ -27,25 +27,13 @@ import (
 	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 )
-
-func CreateServiceAccount(client corev1client.CoreV1Interface, sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-	createdSa, err := client.ServiceAccounts(sa.Namespace).Create(context.Background(), sa, metav1.CreateOptions{})
-	if err != nil {
-		return nil, err
-	}
-	log.Printf("ServiceAccount '%s/%s' successfully created", sa.Namespace, sa.Name)
-
-	return createdSa, nil
-}
 
 // CreateClusterRoleBindings creates the given ClusterRoleBindings in the cluster.
 // In case of failure it will delete and waits for the ClusterRoleBindings to dispose.


### PR DESCRIPTION
`CreateServiceAccount()` was located in the rbac package.
It was moved to the `checkup.serviceaccount` package, because it is only used by checkup.
It was also renamed to `serviceaccount.Create()`.

~~Depends on PR #58.~~