### PR TITLE
CI, checkup/vm-latency: Update linter version and args

### DIFF
--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -37,8 +37,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.44.2
+          version: v1.45.2
           working-directory: ./checkups/kubevirt-vm-latency
+          args: --timeout 3m --verbose vmlatency/... cmd/...
   unit-test:
     name: Unit Test
     runs-on: ubuntu-latest

--- a/checkups/kubevirt-vm-latency/automation/make.sh
+++ b/checkups/kubevirt-vm-latency/automation/make.sh
@@ -72,11 +72,11 @@ if [ "${ARGCOUNT}" -eq "0" ] ; then
 fi
 
 if [ -n "${OPT_LINT}" ]; then
-    golangci_lint_version=v1.44.2
+    golangci_lint_version=v1.45.2
     if [ ! -f $(go env GOPATH)/bin/golangci-lint ]; then
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $golangci_lint_version
     fi
-    golangci-lint run
+    golangci-lint run vmlatency/... cmd/...
 fi
 
 if [ -n "${OPT_UNIT_TEST}" ]; then


### PR DESCRIPTION
The timeout is increased due to the expected codebase size.
The scanned folders are now explicitly specified.

The linter configuration is now in sync with the one from kiagnose core.