### PR TITLE
automation, CI: Introduce basic e2e test infrastructure

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -65,3 +65,18 @@ jobs:
           go-version: ${{ needs.go-versions.outputs.minimal }}
       - name: Run build
         run: ./automation/make.sh --build-core
+  e2e-test:
+    name: e2e
+    runs-on: ubuntu-latest
+    env:
+      KIND: /usr/local/bin/kind
+      KUBECTL: /usr/local/bin/kubectl
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Deploy
+        run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster --deploy-kiagnose
+      - name: Run e2e tests
+        run: ./automation/make.sh --e2e -- --run-tests
+      - name: Delete cluster
+        run: ./automation/make.sh --e2e -- --delete-cluster

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ bin/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Others
+kind
+kubectl

--- a/automation/e2e.sh
+++ b/automation/e2e.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+#
+
+set -e
+
+ARGCOUNT=$#
+
+KUBECTL_VERSION=${KUBECTL_VERSION:-v1.23.0}
+KUBECTL=${KUBECTL:-./kubectl}
+
+KIND_VERSION=${KIND_VERSION:-v0.12.0}
+KIND=${KIND:-./kind}
+
+options=$(getopt --options "" \
+    --long install-kind,install-kubectl,create-cluster,delete-cluster,deploy-kiagnose,run-tests,help\
+    -- "${@}")
+eval set -- "$options"
+while true; do
+    case "$1" in
+    --install-kind)
+        OPT_INSTALL_KIND=1
+        ;;
+    --install-kubectl)
+        OPT_INSTALL_KUBECTL=1
+        ;;
+    --create-cluster)
+        OPT_CREATE_CLUSTER=1
+        ;;
+    --delete-cluster)
+        OPT_DELETE_CLUSTER=1
+        ;;
+    --deploy-kiagnose)
+        OPT_DEPLOY_KIAGNOSE=1
+        ;;
+    --run-tests)
+        OPT_RUN_TEST=1
+        ;;
+    --help)
+        set +x
+        echo "$0 [--install-kind] [--install-kubectl] [--create-cluster] [--delete-cluster] [--deploy-kiagnose] [--run-tests]"
+        exit
+        ;;
+    --)
+        shift
+        break
+        ;;
+    esac
+    shift
+done
+
+if [ "${ARGCOUNT}" -eq "0" ] ; then
+    OPT_INSTALL_KIND=1
+    OPT_INSTALL_KUBECTL=1
+    OPT_CREATE_CLUSTER=1
+    OPT_DEPLOY_KIAGNOSE=1
+    OPT_RUN_TEST=1
+    OPT_DELETE_CLUSTER=1
+fi
+
+if [ -n "${OPT_INSTALL_KIND}" ]; then
+    if [ ! -f "${KIND}" ]; then
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
+        chmod +x ./kind
+        if [ "${KIND}" != "./kind" ]; then
+            mv ./kind "${KIND}"
+        fi
+        echo "kind installed successfully at ${KIND}"
+    fi
+fi
+
+if [ -n "${OPT_INSTALL_KUBECTL}" ]; then
+    if [ ! -f "${KUBECTL}" ]; then
+        curl -LO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+        chmod +x ./kubectl
+        if [ "${KUBECTL}" != "./kubectl" ]; then
+            mv ./kubectl "${KUBECTL}"
+        fi
+        echo "kubectl installed successfully at ${KUBECTL}"
+    fi
+fi
+
+if [ -n "${OPT_CREATE_CLUSTER}" ]; then
+    CLUSTER_NAME=kind
+    if ! ${KIND} get clusters | grep ${CLUSTER_NAME}; then
+        ${KIND} create cluster --wait 2m
+        echo "Waiting for the network to be ready..."
+        ${KUBECTL} wait --for=condition=ready pods --namespace=kube-system -l k8s-app=kube-dns --timeout=2m
+        echo "K8S cluster is up:"
+        ${KUBECTL} get nodes -o wide
+    else
+        echo "Cluster '${CLUSTER_NAME}' already exists!"
+    fi
+fi
+
+if [ -n "${OPT_DEPLOY_KIAGNOSE}" ]; then
+    ${KUBECTL} apply -f manifests/kiagnose.yaml
+fi
+
+if [ -n "${OPT_RUN_TEST}" ]; then
+    # kiagnose sanity e2e test uses the echo-checkup
+    cd checkups/echo
+
+    echo "Post echo checkup ConfigMap & Job:"
+    echo
+    ${KUBECTL} create -f manifests/echo-checkup.yaml
+
+    KIAGNOSE_NAMESPACE=kiagnose
+    KIAGNOSE_JOB=echo-checkup1
+    ECHO_CONFIGMAP=echo-checkup-config
+
+    ${KUBECTL} wait --for=condition=complete --timeout=20s job.batch/${KIAGNOSE_JOB} -n ${KIAGNOSE_NAMESPACE}
+
+    echo
+    echo "Result:"
+    echo
+    ${KUBECTL} get configmap ${ECHO_CONFIGMAP} -n ${KIAGNOSE_NAMESPACE} -o yaml
+    ${KUBECTL} get configmap ${ECHO_CONFIGMAP} -n ${KIAGNOSE_NAMESPACE} -o yaml | grep -q "status.result.echo: Hi!"
+    echo
+    echo "Cleanup:"
+    echo
+    ${KUBECTL} delete -f manifests/echo-checkup.yaml
+
+    cd -
+fi
+
+if [ -n "${OPT_DELETE_CLUSTER}" ]; then
+    ${KIND} delete cluster
+fi

--- a/automation/make.sh
+++ b/automation/make.sh
@@ -33,7 +33,7 @@ CORE_IMAGE="${IMAGE_REGISTRY}/${IMAGE_ORG}/${CORE_IMAGE_NAME}:${CORE_IMAGE_TAG}"
 CORE_BINARY_NAME="kiagnose"
 
 options=$(getopt --options "" \
-    --long lint,unit-test,build-core,build-core-image,push-core-image,help\
+    --long lint,unit-test,build-core,build-core-image,push-core-image,e2e,help\
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -53,9 +53,12 @@ while true; do
     --push-core-image)
         OPT_PUSH_CORE_IMAGE=1
         ;;
+    --e2e)
+        OPT_E2E=1
+        ;;
     --help)
         set +x
-        echo "$0 [--lint] [--unit-test] [--build-core] [--build-core-image] [--push-core-image]"
+        echo "$0 [--lint] [--unit-test] [--e2e] [--build-core] [--build-core-image] [--push-core-image]"
         exit
         ;;
     --)
@@ -98,4 +101,8 @@ fi
 if [ -n "${OPT_PUSH_CORE_IMAGE}" ]; then
     echo "Pushing \"${CORE_IMAGE}\"..."
     ${CRI} push ${CORE_IMAGE}
+fi
+
+if [ -n "${OPT_E2E}" ]; then
+    ./automation/e2e.sh $@
 fi


### PR DESCRIPTION
A dedicated e2e test target has been added to the `make.sh` script.
It delegates all arguments to the new `e2e.sh` script which assists in
deploying a cluster (using `kind`) and `kiagnose`.

The new e2e script also includes a basic sanity validation that deploys
and runs the `echo` checkup.

To run the full set of e2e targets, run:
```
./automation/make.sh --e2e -- \
  --install-kind \
  --install-kubectl \
  --create-cluster \
  --deploy-kiagnose \
  --run-tests \
  --delete-cluster`
```

This PR also includes running the same on CI.

Notes:
- This is a minimalist e2e test validation which should be used as a basic sanity check, assuring the success path for kiagnose.
It is a temporary step until an e2e test suite is introduced.
- The current (explicit) polling could have been improved by using `kubectl wait` command, however I was unable to make it work. Contributing a solution to this is welcome.
- Running the checkup job seems to take a lot of time. We should find the root cause of this and try to reduce it to a minimum (is it the image size?).