### PR TITLE
automation, e2e: Set default binaries with full path

### DIFF
--- a/automation/e2e.sh
+++ b/automation/e2e.sh
@@ -22,10 +22,10 @@ set -e
 ARGCOUNT=$#
 
 KUBECTL_VERSION=${KUBECTL_VERSION:-v1.23.0}
-KUBECTL=${KUBECTL:-./kubectl}
+KUBECTL=${KUBECTL:-$PWD/kubectl}
 
 KIND_VERSION=${KIND_VERSION:-v0.12.0}
-KIND=${KIND:-./kind}
+KIND=${KIND:-$PWD/kind}
 
 options=$(getopt --options "" \
     --long install-kind,install-kubectl,create-cluster,delete-cluster,deploy-kiagnose,run-tests,help\


### PR DESCRIPTION
The default binaries used in the e2e (sanity) tests (`kind` and
`kubectl`) have been set with a relative path (`./`).

This does not work well when running locally.
To solve this, an explicit full path is used instead.