### PR TITLE
kubevirt-vm-latency: Use fedora image

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
@@ -193,12 +193,12 @@ func WithSriovBinding() interfaceOption {
 
 func NewAlpine(name string, opts ...Option) *kvcorev1.VirtualMachineInstance {
 	const (
-		memory                                     = "128Mi"
-		alpineContainerDiskImage                   = "quay.io/kubevirt/alpine-with-test-tooling-container-disk:v0.53.0"
+		memory                                     = "512Mi"
+		fedoraContainerDiskImage                   = "quay.io/kubevirt/fedora-with-test-tooling-container-disk:v0.53.0"
 		defaultTerminationGracePeriodSeconds int64 = 5
 	)
 	latencyCheckOpts := []Option{
-		withContainerDiskImage(alpineContainerDiskImage),
+		withContainerDiskImage(fedoraContainerDiskImage),
 		withTerminationGracePeriodSecond(defaultTerminationGracePeriodSeconds),
 		withResourceMemory(memory),
 		withRng(),


### PR DESCRIPTION
A VM considred ready when AgentConnected condition is met,
meaning that the VM had booted and QEMU Guest Agent (GA) is running.

It seems that the GA wont start on alpine image causing the checkup to
always with VM not read error.

Signed-off-by: Or Mergi <ormergi@redhat.com>