### PR TITLE
kubevirt-vm-latency: Do not set node-selector when node name is empty

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
@@ -62,6 +62,9 @@ func withTerminationGracePeriodSecond(duration int64) Option {
 // WithNodeSelector ensures that the VMI gets scheduled on the specified node.
 func WithNodeSelector(nodeName string) Option {
 	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if nodeName == "" {
+			return
+		}
 		if vmi.Spec.NodeSelector == nil {
 			vmi.Spec.NodeSelector = map[string]string{}
 		}


### PR DESCRIPTION
In order to ensure a VM is scheduled on specific node, the VM node
selector is set with "kubernetes.io/hostname" label.

Setting this label with an empty string (i.e: kubernetes.io/hostname="")
cause the VMs to stuck on 'Scheduling' phase as it looks for a node
that does not exists.
It seems that the value of "kubernetes.io/hostname" label is no validated.

Signed-off-by: Or Mergi <ormergi@redhat.com>