### PR TITLE
latency, vmi, spec: Rename NewAlpine() to NewFedora()

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -124,7 +124,7 @@ func newLatencyCheckVmi(
 			vmi.WithMatchingMAC(macAddress),
 		),
 	)
-	return vmi.NewAlpine(name,
+	return vmi.NewFedora(name,
 		vmi.WithNodeSelector(nodeName),
 		vmi.WithMultusNetwork(networkName, netAttachDef.String()),
 		vmi.WithInterface(

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
@@ -194,7 +194,7 @@ func WithSriovBinding() interfaceOption {
 	}
 }
 
-func NewAlpine(name string, opts ...Option) *kvcorev1.VirtualMachineInstance {
+func NewFedora(name string, opts ...Option) *kvcorev1.VirtualMachineInstance {
 	const (
 		memory                                     = "512Mi"
 		fedoraContainerDiskImage                   = "quay.io/kubevirt/fedora-with-test-tooling-container-disk:v0.53.0"


### PR DESCRIPTION
This PR is a follow up to PR #70 - the OS image was switched from Alpine to Fedora.
Reflect this change in the name of the function that creates this VMI.