### PR TITLE
kubevirt-vm-latency, setup: Wait for source and target VMs until ready

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -104,7 +104,7 @@ func (c *checkup) Setup(ctx context.Context) error {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
 
-	if err := vmi.WaitUntilReady(waitCtx, c.client, c.namespace, targetVmi.Name); err != nil {
+	if err := vmi.WaitUntilReady(waitCtx, c.client, c.namespace, sourceVmi.Name); err != nil {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
 	c.sourceVM = sourceVmi


### PR DESCRIPTION
This PR fixes the checkup setup to wait for both source and target VMs until they are ready.

Signed-off-by: Or Mergi <ormergi@redhat.com>