### PR TITLE
kubevirt-vm-latency ,setup: Fetch VMs latest state when they are ready

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -100,15 +100,14 @@ func (c *checkup) Setup(ctx context.Context) error {
 	waitCtx, cancel := context.WithTimeout(ctx, defaultSetupTimeout)
 	defer cancel()
 
-	if err := vmi.WaitUntilReady(waitCtx, c.client, c.namespace, targetVmi.Name); err != nil {
+	var err error
+	if c.targetVM, err = vmi.WaitUntilReady(waitCtx, c.client, c.namespace, targetVmi.Name); err != nil {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
 
-	if err := vmi.WaitUntilReady(waitCtx, c.client, c.namespace, sourceVmi.Name); err != nil {
+	if c.sourceVM, err = vmi.WaitUntilReady(waitCtx, c.client, c.namespace, sourceVmi.Name); err != nil {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
-	c.sourceVM = sourceVmi
-	c.targetVM = targetVmi
 
 	return nil
 }


### PR DESCRIPTION
With this PR changes the VMs latest state is fetched when they are ready.
Once the VMs are ready their state includes crucial info that will be used by the checkup (i.e: namespace, status..)

Signed-off-by: Or Mergi <ormergi@redhat.com>