### PR TITLE
latency, e2e: Add KUBEVIRT_USE_EMULATION environment variable

### DIFF
--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -78,6 +78,7 @@ jobs:
       KIND: /usr/local/bin/kind
       KUBECTL: /usr/local/bin/kubectl
       CRI: docker
+      KUBEVIRT_USE_EMULATION: true
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -29,6 +29,7 @@ KIND=${KIND:-$PWD/kind}
 CLUSTER_NAME=${CLUSTER_NAME:-kind}
 
 KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-v0.53.0}
+KUBEVIRT_USE_EMULATION=${KUBEVIRT_USE_EMULATION:-"false"}
 CNAO_VERSION=${CNAO_VERSION:-v0.74.0}
 
 FRAMEWORK_IMAGE="quay.io/kiagnose/kiagnose:devel"
@@ -82,7 +83,12 @@ if [ -n "${OPT_DEPLOY_KUBEVIRT}" ]; then
     echo
     kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
     kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
-    kubectl patch kubevirt kubevirt --namespace kubevirt --type=merge --patch '{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}'
+
+    if [ "${KUBEVIRT_USE_EMULATION}" = "true" ]; then
+      echo "Configure Kubevirt to use emulation"
+      kubectl patch kubevirt kubevirt --namespace kubevirt --type=merge --patch '{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}'
+    fi
+
     kubectl wait --for=condition=Available kubevirt kubevirt --namespace=kubevirt --timeout=2m
 
     echo


### PR DESCRIPTION
Add a flag to control the usage of kubevirt's emulation
feature.
Using this flag, makes the e2e tests to run slower, thus it is disabled
by default.
It is enabled in the CI environment.

Signed-off-by: Orel Misan <omisan@redhat.com>