### PR TITLE
latency, CI, e2e: Move general targets to main e2e.sh

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -71,9 +71,12 @@ jobs:
     env:
       KIND: /usr/local/bin/kind
       KUBECTL: /usr/local/bin/kubectl
+      CRI: docker
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+      - name: Build kiagnose image
+        run: ./automation/make.sh --build-core --build-core-image
       - name: Deploy
         run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster --deploy-kiagnose
       - name: Run e2e tests

--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -87,7 +87,7 @@ jobs:
         working-directory: ./checkups/kubevirt-vm-latency
         run: ./automation/make.sh --build-checkup --build-checkup-image
       - name: Start cluster
-        run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster
+        run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster
       - name: Deploy kiagnose
         run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --deploy-kiagnose
       - name: Deploy kubevirt, CNAO and the NetworkAttachementDefinition

--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Start cluster
         run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster
       - name: Deploy kiagnose
-        run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --deploy-kiagnose
+        run: ./automation/make.sh --e2e -- --deploy-kiagnose
       - name: Deploy kubevirt, CNAO and the NetworkAttachementDefinition
         run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --deploy-kubevirt --deploy-cnao --define-nad
       - name: Deploy VM latency checkup

--- a/automation/e2e.sh
+++ b/automation/e2e.sh
@@ -28,6 +28,8 @@ KIND_VERSION=${KIND_VERSION:-v0.12.0}
 KIND=${KIND:-$PWD/kind}
 CLUSTER_NAME=${CLUSTER_NAME:-kind}
 
+FRAMEWORK_IMAGE="quay.io/kiagnose/kiagnose:devel"
+
 options=$(getopt --options "" \
     --long install-kind,install-kubectl,create-cluster,delete-cluster,deploy-kiagnose,run-tests,help\
     -- "${@}")
@@ -103,7 +105,8 @@ if [ -n "${OPT_CREATE_CLUSTER}" ]; then
 fi
 
 if [ -n "${OPT_DEPLOY_KIAGNOSE}" ]; then
-    ${KUBECTL} apply -f manifests/kiagnose.yaml
+  ${KIND} load docker-image "${FRAMEWORK_IMAGE}" --name "${CLUSTER_NAME}"
+  ${KUBECTL} apply -f manifests/kiagnose.yaml
 fi
 
 if [ -n "${OPT_RUN_TEST}" ]; then

--- a/automation/e2e.sh
+++ b/automation/e2e.sh
@@ -26,6 +26,7 @@ KUBECTL=${KUBECTL:-$PWD/kubectl}
 
 KIND_VERSION=${KIND_VERSION:-v0.12.0}
 KIND=${KIND:-$PWD/kind}
+CLUSTER_NAME=${CLUSTER_NAME:-kind}
 
 options=$(getopt --options "" \
     --long install-kind,install-kubectl,create-cluster,delete-cluster,deploy-kiagnose,run-tests,help\
@@ -90,7 +91,6 @@ if [ -n "${OPT_INSTALL_KUBECTL}" ]; then
 fi
 
 if [ -n "${OPT_CREATE_CLUSTER}" ]; then
-    CLUSTER_NAME=kind
     if ! ${KIND} get clusters | grep ${CLUSTER_NAME}; then
         ${KIND} create cluster --wait 2m
         echo "Waiting for the network to be ready..."

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -35,16 +35,13 @@ FRAMEWORK_IMAGE="quay.io/kiagnose/kiagnose:devel"
 CHECKUP_IMAGE="quay.io/kiagnose/kubevirt-vm-latency:devel"
 
 options=$(getopt --options "" \
-    --long delete-cluster,deploy-kiagnose,deploy-kubevirt,deploy-cnao,deploy-checkup,define-nad,run-tests,help\
+    --long delete-cluster,deploy-kubevirt,deploy-cnao,deploy-checkup,define-nad,run-tests,help\
     -- "${@}")
 eval set -- "$options"
 while true; do
     case "$1" in
     --delete-cluster)
         OPT_DELETE_CLUSTER=1
-        ;;
-    --deploy-kiagnose)
-        OPT_DEPLOY_KIAGNOSE=1
         ;;
     --deploy-kubevirt)
         OPT_DEPLOY_KUBEVIRT=1
@@ -64,7 +61,7 @@ while true; do
     --help)
         set +x
         echo -n "$0 [--delete-cluster] "
-        echo -n "[--deploy-kubevirt] [--deploy-kiagnose] [--deploy-cnao] [--deploy-checkup] "
+        echo -n "[--deploy-kubevirt] [--deploy-cnao] [--deploy-checkup] "
         echo "[--define-nad] [--run-tests]"
         exit
         ;;
@@ -77,17 +74,11 @@ while true; do
 done
 
 if [ "${ARGCOUNT}" -eq "0" ] ; then
-    OPT_DEPLOY_KIAGNOSE=1
     OPT_DEPLOY_KUBEVIRT=1
     OPT_DEPLOY_CNAO=1
     OPT_DEPLOY_CHECKUP=1
     OPT_DEFINE_NAD=1
     OPT_RUN_TEST=1
-fi
-
-if [ -n "${OPT_DEPLOY_KIAGNOSE}" ]; then
-  ${KIND} load docker-image "${FRAMEWORK_IMAGE}" --name "${CLUSTER_NAME}"
-  ${KUBECTL} apply -f manifests/kiagnose.yaml
 fi
 
 if [ -n "${OPT_DEPLOY_KUBEVIRT}" ]; then

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -35,14 +35,11 @@ FRAMEWORK_IMAGE="quay.io/kiagnose/kiagnose:devel"
 CHECKUP_IMAGE="quay.io/kiagnose/kubevirt-vm-latency:devel"
 
 options=$(getopt --options "" \
-    --long delete-cluster,deploy-kubevirt,deploy-cnao,deploy-checkup,define-nad,run-tests,help\
+    --long deploy-kubevirt,deploy-cnao,deploy-checkup,define-nad,run-tests,help\
     -- "${@}")
 eval set -- "$options"
 while true; do
     case "$1" in
-    --delete-cluster)
-        OPT_DELETE_CLUSTER=1
-        ;;
     --deploy-kubevirt)
         OPT_DEPLOY_KUBEVIRT=1
         ;;
@@ -60,9 +57,7 @@ while true; do
         ;;
     --help)
         set +x
-        echo -n "$0 [--delete-cluster] "
-        echo -n "[--deploy-kubevirt] [--deploy-cnao] [--deploy-checkup] "
-        echo "[--define-nad] [--run-tests]"
+        echo -n "$0 [--deploy-kubevirt] [--deploy-cnao] [--deploy-checkup] [--define-nad] [--run-tests]"
         exit
         ;;
     --)
@@ -216,8 +211,4 @@ EOF
     echo "Result:"
     echo
     ${KUBECTL} get configmap ${VM_LATENCY_CONFIGMAP} -n ${KIAGNOSE_NAMESPACE} -o yaml
-fi
-
-if [ -n "${OPT_DELETE_CLUSTER}" ]; then
-    ${KIND} delete cluster
 fi

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -23,10 +23,8 @@ ARGCOUNT=$#
 
 SCRIPT_PATH=$(dirname $(realpath -s $0))
 
-KUBECTL_VERSION=${KUBECTL_VERSION:-v1.23.0}
 KUBECTL=${KUBECTL:-$PWD/kubectl}
 
-KIND_VERSION=${KIND_VERSION:-v0.12.0}
 KIND=${KIND:-$PWD/kind}
 CLUSTER_NAME=${CLUSTER_NAME:-kind}
 
@@ -37,20 +35,11 @@ FRAMEWORK_IMAGE="quay.io/kiagnose/kiagnose:devel"
 CHECKUP_IMAGE="quay.io/kiagnose/kubevirt-vm-latency:devel"
 
 options=$(getopt --options "" \
-    --long install-kind,install-kubectl,create-cluster,delete-cluster,deploy-kiagnose,deploy-kubevirt,deploy-cnao,deploy-checkup,define-nad,run-tests,help\
+    --long delete-cluster,deploy-kiagnose,deploy-kubevirt,deploy-cnao,deploy-checkup,define-nad,run-tests,help\
     -- "${@}")
 eval set -- "$options"
 while true; do
     case "$1" in
-    --install-kind)
-        OPT_INSTALL_KIND=1
-        ;;
-    --install-kubectl)
-        OPT_INSTALL_KUBECTL=1
-        ;;
-    --create-cluster)
-        OPT_CREATE_CLUSTER=1
-        ;;
     --delete-cluster)
         OPT_DELETE_CLUSTER=1
         ;;
@@ -74,8 +63,7 @@ while true; do
         ;;
     --help)
         set +x
-        echo -n "$0 [--install-kind] [--install-kubectl] "
-        echo -n "[--create-cluster] [--delete-cluster] "
+        echo -n "$0 [--delete-cluster] "
         echo -n "[--deploy-kubevirt] [--deploy-kiagnose] [--deploy-cnao] [--deploy-checkup] "
         echo "[--define-nad] [--run-tests]"
         exit
@@ -89,43 +77,12 @@ while true; do
 done
 
 if [ "${ARGCOUNT}" -eq "0" ] ; then
-    OPT_INSTALL_KIND=1
-    OPT_INSTALL_KUBECTL=1
-    OPT_CREATE_CLUSTER=1
     OPT_DEPLOY_KIAGNOSE=1
     OPT_DEPLOY_KUBEVIRT=1
     OPT_DEPLOY_CNAO=1
     OPT_DEPLOY_CHECKUP=1
     OPT_DEFINE_NAD=1
     OPT_RUN_TEST=1
-fi
-
-if [ -n "${OPT_INSTALL_KIND}" ]; then
-    if [ ! -f "${KIND}" ]; then
-        curl -Lo ${KIND} https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
-        chmod +x ${KIND}
-        echo "kind installed successfully at ${KIND}"
-    fi
-fi
-
-if [ -n "${OPT_INSTALL_KUBECTL}" ]; then
-    if [ ! -f "${KUBECTL}" ]; then
-        curl -Lo ${KUBECTL} https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
-        chmod +x ${KUBECTL}
-        echo "kubectl installed successfully at ${KUBECTL}"
-    fi
-fi
-
-if [ -n "${OPT_CREATE_CLUSTER}" ]; then
-    if ! ${KIND} get clusters | grep ${CLUSTER_NAME}; then
-        ${KIND} create cluster --wait 2m
-        echo "Waiting for the network to be ready..."
-        ${KUBECTL} wait --for=condition=ready pods --namespace=kube-system -l k8s-app=kube-dns --timeout=2m
-        echo "K8S cluster is up:"
-        ${KUBECTL} get nodes -o wide
-    else
-        echo "Cluster '${CLUSTER_NAME}' already exists!"
-    fi
 fi
 
 if [ -n "${OPT_DEPLOY_KIAGNOSE}" ]; then


### PR DESCRIPTION
The following targets where performed from the latency checkup's `e2e.sh` file:
```
--install-kind
--install-kubectl
--create-cluster
--deploy-kiagnose
```

These targets are general to all checkups, so they were moved to the main `e2e.sh` file.

The `--delete-cluster` target in the checkup's `e2e.sh` script was redundant, because it is also present at the main `e2e.sh` script.