### PR TITLE
checkup, job: Remove redundant event log

### DIFF
--- a/kiagnose/internal/checkup/job/job.go
+++ b/kiagnose/internal/checkup/job/job.go
@@ -21,7 +21,6 @@ package job
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -73,9 +72,6 @@ func waitForJob(ctx context.Context, watcher k8swatch.Interface) (*batchv1.Job, 
 				continue
 			}
 			if finished(job) {
-				if jobStatus, err := json.MarshalIndent(job.Status, "", " "); err == nil {
-					log.Printf("received job event '%s/%s': \n%v\n", job.Namespace, job.Name, string(jobStatus))
-				}
 				return job, nil
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
Events received about the checkup job are currently logged by kiagnose,
but there seem to be no useful reason for such a debug level logging.
(it may be worth the effort once issues are found in this area and a
proper logging library is used to support setting levels of logs)