### PR TITLE
vmlatency, automation, e2e: Create linux-bridge

### DIFF
--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -110,3 +110,17 @@ jobs:
         run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --run-tests
       - name: Delete cluster
         run: ./automation/make.sh --e2e -- --delete-cluster
+  debug:
+    name: test-internal-bridge-net
+    runs-on: ubuntu-latest
+    env:
+      CRI: docker
+    steps:
+    - name: Allow traffic between bridge ports
+      run: | 
+        sudo rmmod br_netfilter
+    - name: Test traffic between bridge ports
+      run : |
+        curl -L -o test.sh "https://gist.githubusercontent.com/ormergi/d4c9bb9679bb1264dc7dac0ad411981a/raw/f5b78bdc935e76cdc5b138da8b734f52e125ed51/connect-netns-w-bridge.sh"
+        sudo chmod +x ./test.sh 
+        sudo ./test.sh

--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -80,6 +80,17 @@ jobs:
       CRI: docker
       KUBEVIRT_USE_EMULATION: true
     steps:
+      - name: Print system config
+        run: |
+          sudo lsmod
+          sudo sysctl -a
+          sudo ip a
+      - name: Enable traffic between bridge ports
+        run: |
+          sudo sysctl -w net.bridge.bridge-nf-call-ip6tables=0
+          sudo sysctl -w net.bridge.bridge-nf-call-iptables=0
+          sudo sysctl -w net.bridge.bridge-nf-call-arptables=0
+          sudo rmmod br_netfilter
       - name: Check out code
         uses: actions/checkout@v2
       - name: Build kiagnose image
@@ -92,7 +103,7 @@ jobs:
       - name: Deploy kiagnose
         run: ./automation/make.sh --e2e -- --deploy-kiagnose
       - name: Deploy kubevirt, CNAO and the NetworkAttachementDefinition
-        run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --deploy-kubevirt --deploy-cnao --create-bridge --define-nad
+        run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --deploy-kubevirt --deploy-cnao --define-nad
       - name: Deploy VM latency checkup
         run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --deploy-checkup
       - name: Run e2e tests

--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Deploy kiagnose
         run: ./automation/make.sh --e2e -- --deploy-kiagnose
       - name: Deploy kubevirt, CNAO and the NetworkAttachementDefinition
-        run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --deploy-kubevirt --deploy-cnao --define-nad
+        run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --deploy-kubevirt --deploy-cnao --create-bridge --define-nad
       - name: Deploy VM latency checkup
         run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --deploy-checkup
       - name: Run e2e tests

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -233,4 +233,10 @@ EOF
     echo "Result:"
     echo
     ${KUBECTL} get configmap ${VM_LATENCY_CONFIGMAP} -n ${KIAGNOSE_NAMESPACE} -o yaml
+
+    succeded=$(${KUBECTL} get configmap ${VM_LATENCY_CONFIGMAP} -n ${KIAGNOSE_NAMESPACE} -o jsonpath='{.data}' | \
+      grep -Po "(?<=\"status.succeeded\":\")(false|true)+")
+    if [ "${succeded}" == "false" ]; then
+      echo "Kubevirt VM latency checkup failed" && exit 1
+    fi
 fi

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -197,7 +197,7 @@ data:
     kubevirt-vmis-manager
   spec.param.network_attachment_definition_namespace: "default"
   spec.param.network_attachment_definition_name: "bridge-network"
-  spec.param.max_desired_latency_milliseconds: "10"
+  spec.param.max_desired_latency_milliseconds: "50"
   spec.param.sample_duration_seconds: "5"
 EOF
 


### PR DESCRIPTION
Currently that latency checkup e2e test fails consistently due to connectivity
issues between the VMs.
Which seems to occur only on KinD (container nodes) clusters, pinging between
two VMs over bridge network on KubevirtCI (VM nodes) cluster works.

Creating a linux-bridge on KIND cluster node in order to set L2 network doesn't
work as expected, there are connectivity issues between VMs over the bridge causing
the checkup to fail.

While troubleshooting, setting an IP address to the bridge solve the issue and
the checkup to ran successfully.

With this commit changes the e2e test will create a linux-bridge with static
IP address that will be used by the checkup.

Signed-off-by: Or Mergi <ormergi@redhat.com>