### PR TITLE
kubevirt-vm-latency: Align automation/e2e.sh script

### DIFF
--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -81,19 +81,19 @@ if [ -n "${OPT_DEPLOY_KUBEVIRT}" ]; then
     echo
     echo "Deploy kubevirt..."
     echo
-    kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
-    kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
+    ${KUBECTL} create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
+    ${KUBECTL} create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
 
     if [ "${KUBEVIRT_USE_EMULATION}" = "true" ]; then
       echo "Configure Kubevirt to use emulation"
-      kubectl patch kubevirt kubevirt --namespace kubevirt --type=merge --patch '{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}'
+      ${KUBECTL} patch kubevirt kubevirt --namespace kubevirt --type=merge --patch '{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}'
     fi
 
-    kubectl wait --for=condition=Available kubevirt kubevirt --namespace=kubevirt --timeout=2m
+    ${KUBECTL} wait --for=condition=Available kubevirt kubevirt --namespace=kubevirt --timeout=2m
 
     echo
     echo "Successfully deployed kubevirt:"
-    kubectl get pods -n kubevirt
+    ${KUBECTL} get pods -n kubevirt
 fi
 
 if [ -n "${OPT_DEPLOY_CNAO}" ]; then
@@ -154,7 +154,7 @@ if [ -n "${OPT_DEPLOY_CHECKUP}" ]; then
     echo
     echo "Deploy kubevirt-vm-latency..."
     echo
-    kubectl create -f ${SCRIPT_PATH}/../manifests/clusterroles.yaml
+    ${KUBECTL} create -f ${SCRIPT_PATH}/../manifests/clusterroles.yaml
 
     ${KIND} load docker-image "${CHECKUP_IMAGE}" --name "${CLUSTER_NAME}"
 fi

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -81,8 +81,8 @@ if [ -n "${OPT_DEPLOY_KUBEVIRT}" ]; then
     echo
     echo "Deploy kubevirt..."
     echo
-    ${KUBECTL} create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
-    ${KUBECTL} create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
+    ${KUBECTL} apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
+    ${KUBECTL} apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
 
     if [ "${KUBEVIRT_USE_EMULATION}" = "true" ]; then
       echo "Configure Kubevirt to use emulation"
@@ -154,7 +154,7 @@ if [ -n "${OPT_DEPLOY_CHECKUP}" ]; then
     echo
     echo "Deploy kubevirt-vm-latency..."
     echo
-    ${KUBECTL} create -f ${SCRIPT_PATH}/../manifests/clusterroles.yaml
+    ${KUBECTL} apply -f ${SCRIPT_PATH}/../manifests/clusterroles.yaml
 
     ${KIND} load docker-image "${CHECKUP_IMAGE}" --name "${CLUSTER_NAME}"
 fi


### PR DESCRIPTION
Currently `e2e.sh` script is not consistent since there are places where `${KUBECTL}` variable is not being used.
And also there are places where `kubectl create ..` is being used and some `kubectl apply ..`.

This PR align's kubevirt-vm-latency change `automation/e2e.sh` script to use `kubectl apply` verb and the `${KUBECTL}` variable.

Executing `kubectl apply` wont fail if the same object is already exists, which makes it easier to iterate on local 
dev environment (i.e: `e2e.sh` wont fail if Kubevirt already deployed).