### PR TITLE
checkup: Randomize ClusterRoleBindings names

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -95,7 +95,7 @@ func New(c kubernetes.Interface, checkupConfig *config.Config, namer namer) *Che
 		roles:               checkupRoles,
 		roleBindings:        checkupRoleBindings,
 		jobTimeout:          checkupConfig.Timeout,
-		clusterRoleBindings: NewClusterRoleBindings(checkupConfig.ClusterRoles, ServiceAccountName, nsName),
+		clusterRoleBindings: NewClusterRoleBindings(checkupConfig.ClusterRoles, ServiceAccountName, nsName, namer),
 		job: NewCheckupJob(
 			JobName,
 			nsName,
@@ -151,11 +151,16 @@ func NewRoleBinding(roleName, namespaceName string, subject rbacv1.Subject) *rba
 	}
 }
 
-func NewClusterRoleBindings(clusterRoles []*rbacv1.ClusterRole, serviceAccountName, serviceAccountNs string) []*rbacv1.ClusterRoleBinding {
+func NewClusterRoleBindings(
+	clusterRoles []*rbacv1.ClusterRole,
+	serviceAccountName,
+	serviceAccountNs string,
+	namer namer) []*rbacv1.ClusterRoleBinding {
 	subject := newServiceAccountSubject(serviceAccountName, serviceAccountNs)
 	var clusterRoleBindings []*rbacv1.ClusterRoleBinding
 	for _, clusterRole := range clusterRoles {
-		clusterRoleBindings = append(clusterRoleBindings, newClusterRoleBinding(clusterRole.Name, clusterRole.Name, subject))
+		clusterRoleBindingName := namer.Name(clusterRole.Name)
+		clusterRoleBindings = append(clusterRoleBindings, newClusterRoleBinding(clusterRoleBindingName, clusterRole.Name, subject))
 	}
 	return clusterRoleBindings
 }

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -155,7 +155,7 @@ func NewClusterRoleBindings(clusterRoles []*rbacv1.ClusterRole, serviceAccountNa
 	subject := newServiceAccountSubject(serviceAccountName, serviceAccountNs)
 	var clusterRoleBindings []*rbacv1.ClusterRoleBinding
 	for _, clusterRole := range clusterRoles {
-		clusterRoleBindings = append(clusterRoleBindings, newClusterRoleBinding(clusterRole.Name, subject))
+		clusterRoleBindings = append(clusterRoleBindings, newClusterRoleBinding(clusterRole.Name, clusterRole.Name, subject))
 	}
 	return clusterRoleBindings
 }
@@ -168,15 +168,16 @@ func newServiceAccountSubject(serviceAccountName, serviceAccountNamespace string
 	}
 }
 
-func newClusterRoleBinding(clusterRoleName string, subject rbacv1.Subject) *rbacv1.ClusterRoleBinding {
+func newClusterRoleBinding(name, clusterRoleName string, subject rbacv1.Subject) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: rbacv1.GroupName},
-		ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Subjects:   []rbacv1.Subject{subject},
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "ClusterRole",
 			APIGroup: rbacv1.GroupName,
-			Name:     clusterRoleName},
+			Name:     clusterRoleName,
+		},
 	}
 }
 


### PR DESCRIPTION
In order to run multiple checkups simultaneously, it is required to randomize the ClusterRoleBinding names, which are non-namespaced objects.

Randomize the names of ClusterRoleBinding objects connecting the user-supplied ClusterRoles with the checkup's ServiceAccount object.

ClusterRoleBinding name format:
`<ClusterRole name>-<random string>`

Fixes issue #17.

~~Depends on PR #89.~~