### PR TITLE
automation: Compile and test with vendor directory

### DIFF
--- a/automation/make.sh
+++ b/automation/make.sh
@@ -34,6 +34,8 @@ CORE_IMAGE="${IMAGE_REGISTRY}/${IMAGE_ORG}/${CORE_IMAGE_NAME}:${CORE_IMAGE_TAG}"
 
 CORE_BINARY_NAME="kiagnose"
 
+export GOFLAGS=-mod=vendor
+
 options=$(getopt --options "" \
     --long lint,unit-test,build-core,build-core-image,push-core-image,e2e,help\
     -- "${@}")

--- a/checkups/kubevirt-vm-latency/automation/make.sh
+++ b/checkups/kubevirt-vm-latency/automation/make.sh
@@ -33,6 +33,8 @@ CHECKUP_IMAGE_NAME="kubevirt-vm-latency"
 CHECKUP_IMAGE_TAG=${CORE_IMAGE_TAG:-devel}
 CHECKUP_IMAGE=${IMAGE_REGISTRY}/${IMAGE_ORG}/${CHECKUP_IMAGE_NAME}:${CHECKUP_IMAGE_TAG}
 
+GOFLAGS=-mod=vendor
+
 options=$(getopt --options "" \
     --long lint,unit-test,build-checkup,build-checkup-image,push-checkup-image,e2e,help\
     -- "${@}")


### PR DESCRIPTION
To ensure that the vendor directory is in sync with the go.mod this
change enforece the "-mod=vendor" go flag to use the vendor at build and
also for running tests.