### PR TITLE
vmlatency, automation, e2e: Allow traffic between bridge ports on CI

### DIFF
--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -80,6 +80,8 @@ jobs:
       CRI: docker
       KUBEVIRT_USE_EMULATION: true
     steps:
+      - name: Unload the br_netfilter kernel module to remove traffic restriction between bridge ports
+        run:  sudo rmmod br_netfilter
       - name: Check out code
         uses: actions/checkout@v2
       - name: Build kiagnose image

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -216,5 +216,12 @@ EOF
     echo
     echo "Result:"
     echo
-    ${KUBECTL} get configmap ${VM_LATENCY_CONFIGMAP} -n ${KIAGNOSE_NAMESPACE} -o yaml
+    results=$(${KUBECTL} get configmap ${VM_LATENCY_CONFIGMAP} -n ${KIAGNOSE_NAMESPACE} -o yaml)
+    echo "${results}"
+
+    if echo "${results}" | grep 'status.succeeded: "false"'; then
+      failureReason=$(echo ${results} | grep -Po "status.failureReason: \K'.+'")
+      echo "Kubevirt VM latency checkup failed: ${failureReason}"
+      exit 1
+    fi
 fi

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -181,7 +181,7 @@ data:
     kubevirt-vmis-manager
   spec.param.network_attachment_definition_namespace: "default"
   spec.param.network_attachment_definition_name: "bridge-network"
-  spec.param.max_desired_latency_milliseconds: "10"
+  spec.param.max_desired_latency_milliseconds: "100"
   spec.param.sample_duration_seconds: "5"
 EOF
 


### PR DESCRIPTION
Following https://github.com/kiagnose/kiagnose/pull/96
Currently kubevirt-vm-latency checkup e2e test fails consistently due to connectivity issues between the VMs.
It seems that on CI environment traffic between bridge ports is blocked causing e2e test to fail 
due to no communication between VMs over the bridge network.

It seems that setting `sysctl -w net.bridge.bridge-nf-call-iptables=0` or adding iptables rule [[1]](https://github.com/kubevirt/cluster-network-addons-operator#configure-bridge-on-node) 
in order to enable traffic between bridge ports doesn't work on Github Workflow environment.

While troubleshooting, it seems that unloading `br_netfilter` removed the restrictions on traffic between bridge 
ports and made the test pass.
Unloading `br_netfilter` kernel module, ensures that the bridge traffic is not inspected (e.g: by iptables)
and thus no packet is dropped.

Thanks to @EdDev for suggesting this.