### PR TITLE
vmlatency, checkup, preflight: Verify NetworkAttachmentDefinition exists

### DIFF
--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -178,7 +178,7 @@ data:
   spec.image: ${CHECKUP_IMAGE}
   spec.timeout: 10m
   spec.clusterRoles: |
-    kubevirt-vmis-manager
+    kubevirt-vm-latency-checker
   spec.param.network_attachment_definition_namespace: "default"
   spec.param.network_attachment_definition_name: "bridge-network"
   spec.param.max_desired_latency_milliseconds: "10"

--- a/checkups/kubevirt-vm-latency/go.mod
+++ b/checkups/kubevirt-vm-latency/go.mod
@@ -4,8 +4,11 @@ go 1.17
 
 require (
 	github.com/google/goexpect v0.0.0-20210430020637-ab937bf7fd6f
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20191119172530-79f836b90111
 	github.com/stretchr/testify v1.7.1
+	google.golang.org/grpc v1.40.0
 	k8s.io/api v0.23.5
+	k8s.io/client-go v12.0.0+incompatible
 	kubevirt.io/api v0.0.0-20220430221853-33880526e414
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -36,7 +39,6 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20191119172530-79f836b90111 // indirect
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
@@ -55,13 +57,11 @@ require (
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2 // indirect
-	google.golang.org/grpc v1.40.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.23.1 // indirect
-	k8s.io/client-go v12.0.0+incompatible // indirect
 	k8s.io/klog/v2 v2.40.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect

--- a/checkups/kubevirt-vm-latency/manifests/clusterroles.yaml
+++ b/checkups/kubevirt-vm-latency/manifests/clusterroles.yaml
@@ -2,11 +2,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubevirt-vmis-manager
+  name: kubevirt-vm-latency-checker
 rules:
 - apiGroups: ["kubevirt.io"]
   resources: ["virtualmachineinstances"]
   verbs: ["get", "create", "delete"]
 - apiGroups: ["subresources.kubevirt.io"]
   resources: ["virtualmachineinstances/console"]
+  verbs: ["get"]
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources: ["network-attachment-definitions"]
   verbs: ["get"]

--- a/checkups/kubevirt-vm-latency/manifests/kubevirt-vm-latency-checkup.yaml
+++ b/checkups/kubevirt-vm-latency/manifests/kubevirt-vm-latency-checkup.yaml
@@ -8,7 +8,7 @@ data:
   spec.image: quay.io/kiagnose/kubevirt-vm-latency-checkup:main
   spec.timeout: 5m
   spec.clusterRoles: |
-    kubevirt-vmis-manager
+    kubevirt-vm-latency-checker
   spec.param.network_attachment_definition_namespace: "default"
   spec.param.network_attachment_definition_name: "sriov-network"
   spec.param.max_desired_latency_milliseconds: "10"

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -62,6 +62,13 @@ func New(c vmi.KubevirtVmisClient, namespace string, params config.CheckupParame
 }
 
 func (c *checkup) Preflight() error {
+	if _, err := c.client.GetNetworkAttachmentDefinition(
+		c.params.NetworkAttachmentDefinitionNamespace,
+		c.params.NetworkAttachmentDefinitionName,
+	); err != nil {
+		return fmt.Errorf("preflight: %v", err)
+	}
+
 	return nil
 }
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
 	kvcorev1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 )
@@ -31,7 +33,12 @@ import (
 type Client struct{ kubecli.KubevirtClient }
 
 func New() (*Client, error) {
-	c, err := kubecli.GetKubevirtClient()
+	kubeconfig, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := kubecli.GetKubevirtClientFromRESTConfig(kubeconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -33,6 +33,8 @@ import (
 	kvcorev1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/checkup"
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/config"
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/launcher"
@@ -229,6 +231,10 @@ func (c *fakeClient) DeleteVirtualMachineInstance(namespace, name string) error 
 }
 
 func (c *fakeClient) SerialConsole(namespace, vmiName string, timeout time.Duration) (kubecli.StreamInterface, error) {
+	return nil, nil
+}
+
+func (c *fakeClient) GetNetworkAttachmentDefinition(_, _ string) (*netattdefv1.NetworkAttachmentDefinition, error) {
 	return nil, nil
 }
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
@@ -31,6 +31,8 @@ import (
 
 	kvcorev1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
+
+	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 )
 
 type KubevirtVmisClient interface {
@@ -38,6 +40,7 @@ type KubevirtVmisClient interface {
 	CreateVirtualMachineInstance(namespace string, vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error)
 	DeleteVirtualMachineInstance(namespace, name string) error
 	SerialConsole(namespace, vmiName string, timeout time.Duration) (kubecli.StreamInterface, error)
+	GetNetworkAttachmentDefinition(namespace, name string) (*netattdefv1.NetworkAttachmentDefinition, error)
 }
 
 func Start(c KubevirtVmisClient, namespace string, vmi *kvcorev1.VirtualMachineInstance) error {


### PR DESCRIPTION
Currently the `NetworkAttachmentDefinition` (NAD) namespace and name are passed
to the checkup, w/o verifying it is exists.
In case the NAD does not exists, the checkup will hang until the timeout, because Kubevirt does
not validate that the NAD exists ending up with VMs that wont schedule.

With this PR changes the checkup will verify that before starting the checkup setup,
if the NAD does not exist it will fail early and wont hang until the timeout.
The checkup ClusterRoles manifest is updated with the required permissions to fetch the NAD.

Note that `go.mod` file is updated, but no new dependencies were added.

Signed-off-by: Or Mergi <ormergi@redhat.com>