### PR TITLE
config: Add a check if checkup image field is empty

### DIFF
--- a/kiagnose/internal/config/cmparser.go
+++ b/kiagnose/internal/config/cmparser.go
@@ -29,6 +29,7 @@ import (
 
 var (
 	ErrImageFieldIsMissing   = errors.New("image field is missing")
+	ErrImageFieldIsIllegal   = errors.New("image field is illegal")
 	ErrTimeoutFieldIsMissing = errors.New("timeout field is missing")
 	ErrTimeoutFieldIsIllegal = errors.New("timeout field is illegal")
 )
@@ -91,6 +92,10 @@ func (cmp *configMapParser) parseImageField() error {
 	cmp.image, exists = cmp.configMapRawData[types.ImageKey]
 	if !exists {
 		return ErrImageFieldIsMissing
+	}
+
+	if cmp.image == "" {
+		return ErrImageFieldIsIllegal
 	}
 
 	return nil

--- a/kiagnose/internal/config/config_test.go
+++ b/kiagnose/internal/config/config_test.go
@@ -148,6 +148,11 @@ func TestReadFromConfigMapShouldFail(t *testing.T) {
 			expectedError: config.ErrImageFieldIsMissing.Error(),
 		},
 		{
+			description:   "when image field value is empty",
+			configMapData: map[string]string{types.ImageKey: "", types.TimeoutKey: timeoutValue},
+			expectedError: config.ErrImageFieldIsIllegal.Error(),
+		},
+		{
 			description:   "when timout field is missing",
 			configMapData: map[string]string{types.ImageKey: imageName},
 			expectedError: config.ErrTimeoutFieldIsMissing.Error(),


### PR DESCRIPTION
Currently, if the kubelet cannot pull the required image - we wait for the required timeout before failing.

Add a check if the image field exists but empty, in order to not wait in vain for timeout expiration.

Signed-off-by: Orel Misan <omisan@redhat.com>