### PR TITLE
config: Add a check if custom param name is empty

### DIFF
--- a/kiagnose/internal/config/cmparser.go
+++ b/kiagnose/internal/config/cmparser.go
@@ -31,6 +31,7 @@ var (
 	ErrImageFieldIsMissing   = errors.New("image field is missing")
 	ErrTimeoutFieldIsMissing = errors.New("timeout field is missing")
 	ErrTimeoutFieldIsIllegal = errors.New("timeout field is illegal")
+	ErrParamNameIsIllegal    = errors.New("param name is illegal")
 )
 
 type configMapParser struct {
@@ -58,7 +59,10 @@ func (cmp *configMapParser) Parse() error {
 		return err
 	}
 
-	cmp.parseParamsField()
+	if err := cmp.parseParamsField(); err != nil {
+		return err
+	}
+
 	cmp.parseClusterRoleNamesField()
 	cmp.parseRoleNamesField()
 
@@ -111,13 +115,19 @@ func (cmp *configMapParser) parseTimeoutField() error {
 	return nil
 }
 
-func (cmp *configMapParser) parseParamsField() {
+func (cmp *configMapParser) parseParamsField() error {
 	for k, v := range cmp.configMapRawData {
 		if strings.HasPrefix(k, types.ParamNameKeyPrefix) {
 			paramName := strings.TrimPrefix(k, types.ParamNameKeyPrefix)
+			if paramName == "" {
+				return ErrParamNameIsIllegal
+			}
+
 			cmp.params[paramName] = v
 		}
 	}
+
+	return nil
 }
 
 func (cmp *configMapParser) parseClusterRoleNamesField() {

--- a/kiagnose/internal/config/config_test.go
+++ b/kiagnose/internal/config/config_test.go
@@ -123,6 +123,8 @@ func TestReadFromConfigMapShouldFail(t *testing.T) {
 		expectedError string
 	}
 
+	const emptyParamName = ""
+
 	failureTestCases := []loadFailureTestCase{
 		{
 			description: "when ConfigMap is already in use",
@@ -176,6 +178,15 @@ func TestReadFromConfigMapShouldFail(t *testing.T) {
 			description:   "when Role name is illegal",
 			configMapData: map[string]string{types.ImageKey: imageName, types.TimeoutKey: timeoutValue, types.RolesKey: "illegal name\n"},
 			expectedError: "role name",
+		},
+		{
+			description: "when param name is empty",
+			configMapData: map[string]string{
+				types.ImageKey:   imageName,
+				types.TimeoutKey: timeoutValue,
+				types.ParamNameKeyPrefix + emptyParamName: "some value",
+			},
+			expectedError: config.ErrParamNameIsIllegal.Error(),
 		},
 	}
 


### PR DESCRIPTION
Until this commit, it was possible to receive an empty string as a valid custom parameter name.

Add a check if a custom parameter name is empty, and fail if it is.

Signed-off-by: Orel Misan <omisan@redhat.com>