### PR TITLE
vm-latency, e2e: Increase deploy kubevirt timeout

### DIFF
--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -89,7 +89,7 @@ if [ -n "${OPT_DEPLOY_KUBEVIRT}" ]; then
       ${KUBECTL} patch kubevirt kubevirt --namespace kubevirt --type=merge --patch '{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}'
     fi
 
-    ${KUBECTL} wait --for=condition=Available kubevirt kubevirt --namespace=kubevirt --timeout=2m
+    ${KUBECTL} wait --for=condition=Available kubevirt kubevirt --namespace=kubevirt --timeout=5m
 
     echo
     echo "Successfully deployed kubevirt:"


### PR DESCRIPTION
Currently kubevirt deployment timeout is set to 2 minutes. This
sometimes fail when running locally.
This PR is aligning the timeout to 5m which is the same as kubevirt repo's own deploy
complete [wait](https://github.com/kubevirt/kubevirt/blob/main/hack/cluster-deploy.sh#L128
).