### PR TITLE
vm-latency, e2e: Add bridge NetworkAttachmentDefinition

### DIFF
--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -127,27 +127,7 @@ if [ -n "${OPT_DEFINE_NAD}" ]; then
     echo
     echo "Define NetworkAttachmentDefinition (with a bridge CNI)..."
     echo
-    cat <<EOF | ${KUBECTL} apply -f -
----
-apiVersion: k8s.cni.cncf.io/v1
-kind: NetworkAttachmentDefinition
-metadata:
-  name: bridge-network
-  namespace: default
-spec:
-  config: |
-    {
-      "cniVersion":"0.3.1",
-      "name": "br10",
-      "plugins": [
-          {
-              "type": "cnv-bridge",
-              "bridge": "br10"
-          }
-      ]
-    }
-EOF
-
+    ${KUBECTL} apply -f ${SCRIPT_PATH}/../manifests/bridge-network-attachment-definition.yaml
 fi
 
 if [ -n "${OPT_DEPLOY_CHECKUP}" ]; then

--- a/checkups/kubevirt-vm-latency/manifests/bridge-network-attachment-definition.yaml
+++ b/checkups/kubevirt-vm-latency/manifests/bridge-network-attachment-definition.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bridge-network
+  namespace: default
+spec:
+  config: |
+    {
+      "cniVersion":"0.3.1",
+      "name": "br10",
+      "plugins": [
+          {
+              "type": "cnv-bridge",
+              "bridge": "br10"
+          }
+      ]
+    }


### PR DESCRIPTION
Currently, the NetworkAttachmentDefinition for a bridge network is created on-the-fly in the e2e.sh script.

Add bridge NetworkAttachmentDefinition manifest as a file, so users could also consume it as an example.

Signed-off-by: Orel Misan <omisan@redhat.com>