### PR TITLE
checkup, tests: Fix assertClusterRoleBindingsCreated()

### DIFF
--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -647,7 +647,7 @@ func assertClusterRoleBindingsCreated(
 	for _, clusterRoleBindingPtr := range checkup.NewClusterRoleBindings(clusterRoles, checkup.ServiceAccountName, nsName, nameGen) {
 		expectedClusterRoleBindings = append(expectedClusterRoleBindings, *clusterRoleBindingPtr)
 	}
-	assert.Subset(t, actualClusterRoleBindings, expectedClusterRoleBindings)
+	assert.Equal(t, actualClusterRoleBindings, expectedClusterRoleBindings)
 }
 
 // assertNoObjectExists checks that the checkup's Namespace and ClusterRoleBinding's are deleted.


### PR DESCRIPTION
Currently, assertClusterRoleBindingsCreated() is checking if the expected ClusterRoleBinding objects are a subset of the actual objects.

Change the assertion to `Equal()`, because the expected objects should match the actual ones.

Signed-off-by: Orel Misan <omisan@redhat.com>