### PR TITLE
Kubevirt VM latency checkup: Use alpine image for VMs

### DIFF
--- a/checkups/kubevirt-vm-latency/go.mod
+++ b/checkups/kubevirt-vm-latency/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/google/goexpect v0.0.0-20210430020637-ab937bf7fd6f
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20191119172530-79f836b90111
 	github.com/stretchr/testify v1.7.1
-	google.golang.org/grpc v1.40.0
 	k8s.io/api v0.23.5
 	k8s.io/client-go v12.0.0+incompatible
 	kubevirt.io/api v0.0.0-20220430221853-33880526e414
@@ -58,6 +57,7 @@ require (
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2 // indirect
+	google.golang.org/grpc v1.40.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -132,7 +132,7 @@ func newLatencyCheckVmi(
 		vmiInterface = vmi.NewInterface(networkName, vmi.WithMacAddress(macAddress), vmi.WithBridgeBinding())
 	}
 
-	return vmi.NewFedora(name,
+	return vmi.NewAlpine(name,
 		vmi.WithNodeSelector(nodeName),
 		vmi.WithMultusNetwork(networkName, netAttachDef.Namespace+"/"+netAttachDef.Name),
 		vmi.WithInterface(vmiInterface),

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/console/console.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/console/console.go
@@ -29,8 +29,6 @@ import (
 
 	expect "github.com/google/goexpect"
 
-	"google.golang.org/grpc/codes"
-
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -51,8 +49,8 @@ func NewConsole(client kubevmi.KubevirtVmisClient, vmi *v1.VirtualMachineInstanc
 	return Console{client: client, vmi: vmi}
 }
 
-// LoginToFedora performs a console login to a Fedora base VM
-func (c Console) LoginToFedora() error {
+// LoginToAlpine performs a console login to an Alpine based VM
+func (c Console) LoginToAlpine() error {
 	const connectTimeout = 10 * time.Second
 	expecter, err := c.newExpecter(connectTimeout)
 	if err != nil {
@@ -67,44 +65,17 @@ func (c Console) LoginToFedora() error {
 	// Do not login, if we already logged in
 	b := []expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: fmt.Sprintf(`(\[fedora@(localhost|fedora|%s) ~\]\$ |\[root@(localhost|fedora|%s) fedora\]\# )`, c.vmi.Name, c.vmi.Name)},
+		&expect.BExp{R: fmt.Sprintf(`(localhost|%s):~\# `, c.vmi.Name)},
 	}
 	const batchIsLoggedTimeout = 5 * time.Second
 	if _, e := expecter.ExpectBatch(b, batchIsLoggedTimeout); e == nil {
 		return nil
 	}
 
-	vmi := c.vmi
-
 	b = []expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BSnd{S: "\n"},
-		&expect.BCas{C: []expect.Caser{
-			&expect.Case{
-				// Using only "login: " would match things like "Last failed login: Tue Jun  9 22:25:30 UTC 2020 on ttyS0"
-				// and in case the VM's did not get hostname form DHCP server try the default hostname
-				R:  regexp.MustCompile(fmt.Sprintf(`(localhost|fedora|%s) login: `, vmi.Name)),
-				S:  "fedora\n",
-				T:  expect.Next(),
-				Rt: 10,
-			},
-			&expect.Case{
-				R:  regexp.MustCompile(`Password:`),
-				S:  "fedora\n",
-				T:  expect.Next(),
-				Rt: 10,
-			},
-			&expect.Case{
-				R:  regexp.MustCompile(`Login incorrect`),
-				T:  expect.LogContinue("Failed to log in", expect.NewStatus(codes.PermissionDenied, "login failed")),
-				Rt: 10,
-			},
-			&expect.Case{
-				R: regexp.MustCompile(fmt.Sprintf(`\[fedora@(localhost|fedora|%s) ~\]\$ `, vmi.Name)),
-				T: expect.OK(),
-			},
-		}},
-		&expect.BSnd{S: "sudo su\n"},
+		&expect.BExp{R: fmt.Sprintf(`(localhost|%s) login: `, c.vmi.Name)},
+		&expect.BSnd{S: "root\n"},
 		&expect.BExp{R: PromptExpression},
 	}
 	const batchLoginTimeout = 2 * time.Minute

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/latency.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/latency.go
@@ -60,7 +60,7 @@ func (l *Latency) Check(sourceVMI, targetVMI *kvcorev1.VirtualMachineInstance, s
 	const errMessagePrefix = "failed to run check"
 	sourceVMIConsole := console.NewConsole(l.client, sourceVMI)
 
-	if err := sourceVMIConsole.LoginToFedora(); err != nil {
+	if err := sourceVMIConsole.LoginToAlpine(); err != nil {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/latency.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/latency.go
@@ -73,11 +73,17 @@ func (l *Latency) Check(sourceVMI, targetVMI *kvcorev1.VirtualMachineInstance, s
 	}
 
 	const runCommandGracePeriod = time.Minute * 1
+	start := time.Now()
 	res, err := sourceVMIConsole.RunCommand(composePingCommand(targetIPAddress, sampleTime), sampleTime+runCommandGracePeriod)
+	pingTime := time.Since(start)
 	if err != nil {
 		return err
 	}
 	l.results = ParsePingResults(res)
+
+	if l.results.Time == 0 {
+		l.results.Time = pingTime
+	}
 
 	if l.results.Transmitted == 0 || l.results.Received == 0 {
 		return fmt.Errorf("%s: failed due to connectivity issue: %d packets transmitted, %d packets received",

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser.go
@@ -46,8 +46,8 @@ func ParsePingResults(pingResult string) Results {
 	var results Results
 	var err error
 
-	statisticsPattern := regexp.MustCompile(`(\d+)\s*\S*packets\s*transmitted,\s*(\d+)\s*received,\s*(\d+)%\s*packet\s*loss,\s*time\s*(\d+)`)
-	statisticsPatternMatches := statisticsPattern.FindAllStringSubmatch(pingResult, -1)
+	p := regexp.MustCompile(`(\d+)\s*\S*packets\s*transmitted,\s*(\d+)\s*(packets )?received,\s*(\d+)%\s*packet\s*loss(, time (\d+))?`)
+	statisticsPatternMatches := p.FindAllStringSubmatch(pingResult, -1)
 	for _, item := range statisticsPatternMatches {
 		if results.Transmitted, err = strconv.Atoi(strings.TrimSpace(item[1])); err != nil {
 			log.Printf("%s: failed to parse 'time': %v", errMessagePrefix, err)
@@ -57,12 +57,12 @@ func ParsePingResults(pingResult string) Results {
 			log.Printf("%s: failed to parse 'time': %v", errMessagePrefix, err)
 		}
 
-		if results.Time, err = time.ParseDuration(fmt.Sprintf("%s%s", strings.TrimSpace(item[4]), millisecondsPrefix)); err != nil {
+		if results.Time, err = time.ParseDuration(fmt.Sprintf("%s%s", strings.TrimSpace(item[6]), millisecondsPrefix)); err != nil {
 			log.Printf("%s: failed to parse 'time': %v", errMessagePrefix, err)
 		}
 	}
 
-	latencyPattern := regexp.MustCompile(`(round-trip|rtt)\s+\S+\s*=\s*([0-9.]+)/([0-9.]+)/([0-9.]+)/([0-9.]+)\s*ms`)
+	latencyPattern := regexp.MustCompile(`(round-trip|rtt)\s+\S+\s*=\s*([0-9.]+)/([0-9.]+)/([0-9.]+)(/[0-9.]+)?\s*ms`)
 	latencyPatternMatches := latencyPattern.FindAllStringSubmatch(pingResult, -1)
 	for _, item := range latencyPatternMatches {
 		if results.Min, err = time.ParseDuration(fmt.Sprintf("%s%s", strings.TrimSpace(item[2]), millisecondsPrefix)); err != nil {

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
@@ -29,8 +29,7 @@ import (
 )
 
 func TestParsePingResults(t *testing.T) {
-	const (
-		pingOutput = `
+	const pingOutput = `
 PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
 64 bytes from 1.1.1.1: icmp_seq=1 ttl=58 time=2.17 ms
 64 bytes from 1.1.1.1: icmp_seq=2 ttl=58 time=1.98 ms
@@ -42,7 +41,6 @@ PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
 5 packets transmitted, 5 received, 0% packet loss, time 4004ms
 rtt min/avg/max/mdev = 1.732/2.074/2.382/0.214 ms
 `
-	)
 	expectedResults := latency.Results{
 		Transmitted: 5,
 		Received:    5,

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
@@ -61,3 +61,34 @@ rtt min/avg/max/mdev = 1.732/2.074/2.382/0.214 ms
 
 	assert.Equal(t, latency.ParsePingResults(pingOutput), expectedResults)
 }
+
+func TestParseBusyBoxPingResults(t *testing.T) {
+	const pingOutput = `
+PING 192.168.100.20 (192.168.100.20): 56 data bytes
+64 bytes from 192.168.100.20: seq=0 ttl=64 time=0.314 ms
+64 bytes from 192.168.100.20: seq=1 ttl=64 time=0.340 ms
+64 bytes from 192.168.100.20: seq=2 ttl=64 time=0.461 ms
+64 bytes from 192.168.100.20: seq=3 ttl=64 time=0.332 ms
+64 bytes from 192.168.100.20: seq=4 ttl=64 time=0.395 ms
+
+--- 192.168.100.20 ping statistics ---
+5 packets transmitted, 5 packets received, 0% packet loss
+round-trip min/avg/max = 0.314/0.368/0.461 ms
+`
+	expectedResults := latency.Results{
+		Transmitted: 5,
+		Received:    5,
+	}
+	var err error
+	if expectedResults.Min, err = time.ParseDuration("0.314ms"); err != nil {
+		panic(err)
+	}
+	if expectedResults.Average, err = time.ParseDuration("0.368ms"); err != nil {
+		panic(err)
+	}
+	if expectedResults.Max, err = time.ParseDuration("0.461ms"); err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, latency.ParsePingResults(pingOutput), expectedResults)
+}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
@@ -203,14 +203,16 @@ func WithBridgeBinding() interfaceOption {
 	}
 }
 
-func NewFedora(name string, opts ...Option) *kvcorev1.VirtualMachineInstance {
+func NewAlpine(name string, opts ...Option) *kvcorev1.VirtualMachineInstance {
 	const (
-		memory                                     = "512Mi"
-		fedoraContainerDiskImage                   = "quay.io/kubevirt/fedora-with-test-tooling-container-disk:v0.53.0"
+		memory                                     = "128Mi"
 		defaultTerminationGracePeriodSeconds int64 = 5
+
+		containerDiskImage = "quay.io/kubevirtci/alpine-with-test-tooling-container-disk" +
+			"@sha256:a40c4a7bb9644098740ad5f8aa64040b0a64bb84cc4e3b42d633bb752ab4b9ce"
 	)
 	latencyCheckOpts := []Option{
-		withContainerDiskImage(fedoraContainerDiskImage),
+		withContainerDiskImage(containerDiskImage),
 		withTerminationGracePeriodSecond(defaultTerminationGracePeriodSeconds),
 		withResourceMemory(memory),
 		withRng(),


### PR DESCRIPTION
Currently, the checkup VMs image is Fedora-based container disk `quay.io/kubevirt/fedora-with-test-tooling-container-disk`.

Alpine image is much lighter than a similar fedora image, it boots faster and requires less resources.

This PR also changes the checkup to use Alpine image.
Since Alpine includes `BusyBox` `ping` implementation which generates a slightly different output the `iputils` version,
the ping parser code is changed accordingly.
That there is an effort to refactor the ping parser code at https://github.com/kiagnose/kiagnose/pull/116.

Note about the VM image tag, since Kubevirt is not released with [[2]](https://github.com/kubevirt/kubevirt/pull/7783) changes yet `quay.io/kubevirtci/alpine-with-test-tooling-container-disk` tag is used.

Signed-off-by: Or Mergi <ormergi@redhat.com>