### PR TITLE
Kubevirt VM latnecy, e2e: Increase CNAO ready timeout

### DIFF
--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -123,7 +123,7 @@ spec:
   multus: {}
 EOF
 
-    ${KUBECTL} wait --for condition=Available networkaddonsconfig cluster --timeout=2m
+    ${KUBECTL} wait --for condition=Available networkaddonsconfig cluster --timeout=5m
 
     echo
     echo "Successfully deployed CNAO:"


### PR DESCRIPTION
E2E check on CI sometimes fail due to timeout when waiting for CNAO to be ready.

Signed-off-by: Or Mergi <ormergi@redhat.com>