### PR TITLE
actions: Push tags to quay.io

### DIFF
--- a/.github/workflows/checkup-echo.publish.yaml
+++ b/.github/workflows/checkup-echo.publish.yaml
@@ -2,7 +2,10 @@ name: checkup-echo.publish
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - main
+    tags:
+    - 'v*.*.*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -15,7 +18,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      ECHO_IMAGE_TAG: main
+      ECHO_IMAGE_TAG: ${{github.ref_name}}
       CRI: podman
     steps:
       - name: Check out code

--- a/.github/workflows/checkup-kubevirt-vm-latency.publish.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.publish.yaml
@@ -2,7 +2,10 @@ name: checkup-kubevirt-vm-latency.publish
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - main
+    tags:
+    - 'v*.*.*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -11,7 +14,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      CHECKUP_IMAGE_TAG: main
+      CHECKUP_IMAGE_TAG: ${{github.ref_name}}
       CRI: podman
       CHECKUP: kubevirt-vm-latency
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,8 +2,10 @@ name: publish
 
 on:
   push:
-    branches: [ main ]
-
+    branches:
+    - main
+    tags:
+    - 'v*.*.*'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -21,8 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: go-versions
     env:
-      CORE_IMAGE_TAG: main
-      ECHO_IMAGE_TAG: main
+      CORE_IMAGE_TAG: ${{github.ref_name}}
       CRI: podman
     steps:
       - name: Check out code


### PR DESCRIPTION
When repository is tagged with a semver it need to also tag the
generated containers at quay.io, this changes add a new trigger to push
containers and use the trigger ref to tag the container.

Signed-off-by: Enrique Llorente <ellorent@redhat.com>