### PR TITLE
echo, README: Replace serviceAccount to serviceAccountName

### DIFF
--- a/checkups/echo/README.md
+++ b/checkups/echo/README.md
@@ -46,7 +46,7 @@ spec:
   backoffLimit: 0
   template:
     spec:
-      serviceAccount: kiagnose
+      ServiceAccountName: kiagnose
       restartPolicy: Never
       containers:
         - name: framework


### PR DESCRIPTION
Replace the deprecated [1] `serviceAccount` field to `serviceAccountName`.

[1] https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#deprecated

Signed-off-by: Orel Misan <omisan@redhat.com>