### PR TITLE
checkup: Name results CM after user-supplied CM

### DIFF
--- a/kiagnose/mainflow.go
+++ b/kiagnose/mainflow.go
@@ -44,6 +44,10 @@ func Run(env map[string]string) error {
 		return err
 	}
 
-	l := launcher.New(checkup.New(c, checkupConfig, namegenerator.NameGenerator{}), reporter.New(c, configMapNamespace, configMapName))
+	l := launcher.New(
+		checkup.New(c, configMapName, checkupConfig, namegenerator.NameGenerator{}),
+		reporter.New(c, configMapNamespace, configMapName),
+	)
+
 	return l.Run()
 }


### PR DESCRIPTION
Currently, the results ConfigMap object's name is constant.
As a preliminary step to checkup execution in a target namespace,
name the results ConfigMap with the following format:
`<user-supplied-CM-name>-results`

Signed-off-by: Orel Misan <omisan@redhat.com>