### PR TITLE
vm latency, e2e: Increase max latency threshold

### DIFF
--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -184,7 +184,7 @@ data:
     kubevirt-vm-latency-checker
   spec.param.network_attachment_definition_namespace: "default"
   spec.param.network_attachment_definition_name: "bridge-network"
-  spec.param.max_desired_latency_milliseconds: "100"
+  spec.param.max_desired_latency_milliseconds: "500"
   spec.param.sample_duration_seconds: "5"
 EOF
 


### PR DESCRIPTION
Occasionally, the latency measured on Github Actions is greater
than the defined threshold, which causes the e2e test to fail.
Increase the max latency by a factor of 5.

Signed-off-by: Orel Misan <omisan@redhat.com>