### PR TITLE
checkup: Re-order the functions

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -231,16 +231,6 @@ func NewCheckupJob(namespaceName, name, serviceAccountName, image string, active
 	}
 }
 
-func concentrateErrors(errs []error) error {
-	sb := strings.Builder{}
-	for _, err := range errs {
-		sb.WriteString(err.Error())
-		sb.WriteString("\n")
-	}
-
-	return errors.New(sb.String())
-}
-
 func NameResultsConfigMap(checkupName string) string {
 	return checkupName + "-results"
 }
@@ -251,4 +241,14 @@ func NameResultsConfigMapWriterRole(checkupName string) string {
 
 func NameJob(checkupName string) string {
 	return checkupName
+}
+
+func concentrateErrors(errs []error) error {
+	sb := strings.Builder{}
+	for _, err := range errs {
+		sb.WriteString(err.Error())
+		sb.WriteString("\n")
+	}
+
+	return errors.New(sb.String())
 }


### PR DESCRIPTION
Change the structure of checkup.go:
1. Main constructor function.
2. Checkup's methods
3. Helper constructors.
4. Helper functions.