### PR TITLE
checkup: Align functions to receive namespace first and name second

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -74,7 +74,7 @@ func New(c kubernetes.Interface, name string, checkupConfig *config.Config, name
 	jobName := NameJob(name)
 	checkupRoles := []*rbacv1.Role{NewConfigMapWriterRole(nsName, resultsConfigMapWriterRoleName, resultsConfigMapName)}
 
-	subject := newServiceAccountSubject(serviceAccountName, nsName)
+	subject := newServiceAccountSubject(nsName, serviceAccountName)
 	var checkupRoleBindings []*rbacv1.RoleBinding
 	for _, role := range checkupRoles {
 		checkupRoleBindings = append(checkupRoleBindings, NewRoleBinding(nsName, role.Name, subject))
@@ -157,7 +157,7 @@ func NewClusterRoleBindings(
 	serviceAccountNs,
 	serviceAccountName string,
 	namer namer) []*rbacv1.ClusterRoleBinding {
-	subject := newServiceAccountSubject(serviceAccountName, serviceAccountNs)
+	subject := newServiceAccountSubject(serviceAccountNs, serviceAccountName)
 	var clusterRoleBindings []*rbacv1.ClusterRoleBinding
 	for _, clusterRole := range clusterRoles {
 		clusterRoleBindingName := namer.Name(clusterRole.Name)
@@ -166,7 +166,7 @@ func NewClusterRoleBindings(
 	return clusterRoleBindings
 }
 
-func newServiceAccountSubject(serviceAccountName, serviceAccountNamespace string) rbacv1.Subject {
+func newServiceAccountSubject(serviceAccountNamespace, serviceAccountName string) rbacv1.Subject {
 	return rbacv1.Subject{
 		Kind:      rbacv1.ServiceAccountKind,
 		Name:      serviceAccountName,

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -77,7 +77,7 @@ func New(c kubernetes.Interface, name string, checkupConfig *config.Config, name
 	subject := newServiceAccountSubject(serviceAccountName, nsName)
 	var checkupRoleBindings []*rbacv1.RoleBinding
 	for _, role := range checkupRoles {
-		checkupRoleBindings = append(checkupRoleBindings, NewRoleBinding(role.Name, nsName, subject))
+		checkupRoleBindings = append(checkupRoleBindings, NewRoleBinding(nsName, role.Name, subject))
 	}
 
 	checkupEnvVars := []corev1.EnvVar{
@@ -143,7 +143,7 @@ func newConfigMapWriterPolicyRule(cmName string) rbacv1.PolicyRule {
 	}
 }
 
-func NewRoleBinding(roleName, namespaceName string, subject rbacv1.Subject) *rbacv1.RoleBinding {
+func NewRoleBinding(namespaceName, roleName string, subject rbacv1.Subject) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: rbacv1.GroupName},
 		ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: namespaceName},

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -72,7 +72,7 @@ func New(c kubernetes.Interface, name string, checkupConfig *config.Config, name
 	resultsConfigMapWriterRoleName := NameResultsConfigMapWriterRole(name)
 	serviceAccountName := NameServiceAccount(name)
 	jobName := NameJob(name)
-	checkupRoles := []*rbacv1.Role{NewConfigMapWriterRole(resultsConfigMapWriterRoleName, nsName, resultsConfigMapName)}
+	checkupRoles := []*rbacv1.Role{NewConfigMapWriterRole(nsName, resultsConfigMapWriterRoleName, resultsConfigMapName)}
 
 	subject := newServiceAccountSubject(serviceAccountName, nsName)
 	var checkupRoleBindings []*rbacv1.RoleBinding
@@ -126,7 +126,7 @@ func NewConfigMap(namespaceName, name string) *corev1.ConfigMap {
 	}
 }
 
-func NewConfigMapWriterRole(name, namespaceName, configMapName string) *rbacv1.Role {
+func NewConfigMapWriterRole(namespaceName, name, configMapName string) *rbacv1.Role {
 	return &rbacv1.Role{
 		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: rbacv1.GroupName},
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespaceName},

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -96,7 +96,7 @@ func New(c kubernetes.Interface, name string, checkupConfig *config.Config, name
 		roles:               checkupRoles,
 		roleBindings:        checkupRoleBindings,
 		jobTimeout:          checkupConfig.Timeout,
-		clusterRoleBindings: NewClusterRoleBindings(checkupConfig.ClusterRoles, serviceAccountName, nsName, namer),
+		clusterRoleBindings: NewClusterRoleBindings(checkupConfig.ClusterRoles, nsName, serviceAccountName, namer),
 		job: NewCheckupJob(
 			jobName,
 			nsName,
@@ -154,8 +154,8 @@ func NewRoleBinding(namespaceName, roleName string, subject rbacv1.Subject) *rba
 
 func NewClusterRoleBindings(
 	clusterRoles []*rbacv1.ClusterRole,
-	serviceAccountName,
-	serviceAccountNs string,
+	serviceAccountNs,
+	serviceAccountName string,
 	namer namer) []*rbacv1.ClusterRoleBinding {
 	subject := newServiceAccountSubject(serviceAccountName, serviceAccountNs)
 	var clusterRoleBindings []*rbacv1.ClusterRoleBinding

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -98,8 +98,8 @@ func New(c kubernetes.Interface, name string, checkupConfig *config.Config, name
 		jobTimeout:          checkupConfig.Timeout,
 		clusterRoleBindings: NewClusterRoleBindings(checkupConfig.ClusterRoles, nsName, serviceAccountName, namer),
 		job: NewCheckupJob(
-			jobName,
 			nsName,
+			jobName,
 			serviceAccountName,
 			checkupConfig.Image,
 			int64(checkupConfig.Timeout.Seconds()),
@@ -187,7 +187,7 @@ func newClusterRoleBinding(name, clusterRoleName string, subject rbacv1.Subject)
 	}
 }
 
-func NewCheckupJob(name, namespaceName, serviceAccountName, image string, activeDeadlineSeconds int64, envs []corev1.EnvVar) *batchv1.Job {
+func NewCheckupJob(namespaceName, name, serviceAccountName, image string, activeDeadlineSeconds int64, envs []corev1.EnvVar) *batchv1.Job {
 	const containerName = "checkup"
 
 	checkupContainer := corev1.Container{Name: containerName, Image: image, Env: envs}

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -92,7 +92,7 @@ func New(c kubernetes.Interface, name string, checkupConfig *config.Config, name
 		teardownTimeout:     defaultTeardownTimeout,
 		namespace:           NewNamespace(nsName),
 		serviceAccount:      NewServiceAccount(nsName, serviceAccountName),
-		resultConfigMap:     NewConfigMap(resultsConfigMapName, nsName),
+		resultConfigMap:     NewConfigMap(nsName, resultsConfigMapName),
 		roles:               checkupRoles,
 		roleBindings:        checkupRoleBindings,
 		jobTimeout:          checkupConfig.Timeout,
@@ -120,7 +120,7 @@ func NewServiceAccount(namespaceName, name string) *corev1.ServiceAccount {
 	}
 }
 
-func NewConfigMap(name, namespaceName string) *corev1.ConfigMap {
+func NewConfigMap(namespaceName, name string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespaceName},
 	}

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -91,7 +91,7 @@ func New(c kubernetes.Interface, name string, checkupConfig *config.Config, name
 		client:              c,
 		teardownTimeout:     defaultTeardownTimeout,
 		namespace:           NewNamespace(nsName),
-		serviceAccount:      NewServiceAccount(serviceAccountName, nsName),
+		serviceAccount:      NewServiceAccount(nsName, serviceAccountName),
 		resultConfigMap:     NewConfigMap(resultsConfigMapName, nsName),
 		roles:               checkupRoles,
 		roleBindings:        checkupRoleBindings,
@@ -114,7 +114,7 @@ func NewNamespace(name string) *corev1.Namespace {
 	}
 }
 
-func NewServiceAccount(name, namespaceName string) *corev1.ServiceAccount {
+func NewServiceAccount(namespaceName, name string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespaceName},
 	}

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -663,7 +663,7 @@ func assertClusterRoleBindingsCreated(
 	assert.NoError(t, err)
 
 	var expectedClusterRoleBindings []rbacv1.ClusterRoleBinding
-	for _, clusterRoleBindingPtr := range checkup.NewClusterRoleBindings(clusterRoles, serviceAccountName, nsName, nameGen) {
+	for _, clusterRoleBindingPtr := range checkup.NewClusterRoleBindings(clusterRoles, nsName, serviceAccountName, nameGen) {
 		expectedClusterRoleBindings = append(expectedClusterRoleBindings, *clusterRoleBindingPtr)
 	}
 	assert.Equal(t, actualClusterRoleBindings, expectedClusterRoleBindings)

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -647,7 +647,7 @@ func assertConfigMapWriterRoleBindingCreated(t *testing.T, testClient *fake.Clie
 	assert.NoError(t, err)
 
 	subject := rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: serviceAccountName, Namespace: nsName}
-	expectedRoleBinding := checkup.NewRoleBinding(roleName, nsName, subject)
+	expectedRoleBinding := checkup.NewRoleBinding(nsName, roleName, subject)
 
 	assert.Equal(t, expectedRoleBinding, actualRoleBinding)
 }

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -324,7 +324,7 @@ func TestCheckupRunShouldCreateAJob(t *testing.T) {
 
 			serviceAccountName := checkup.NameServiceAccount(testCheckupName)
 			expectedJob := checkup.NewCheckupJob(
-				checkupJobName, checkupNamespaceName, serviceAccountName, testImage, int64(testTimeout.Seconds()), expectedEnvVars)
+				checkupNamespaceName, checkupJobName, serviceAccountName, testImage, int64(testTimeout.Seconds()), expectedEnvVars)
 			actualJob, err := testClient.BatchV1().Jobs(checkupNamespaceName).Get(context.Background(), checkupJobName, metav1.GetOptions{})
 			assert.NoError(t, err)
 

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -626,7 +626,7 @@ func assertResultsConfigMapCreated(t *testing.T, testClient *fake.Clientset, nsN
 	actualConfigMap, err := testClient.Tracker().Get(gvr, nsName, expectedConfigMapName)
 
 	assert.NoError(t, err)
-	assert.Equal(t, checkup.NewConfigMap(expectedConfigMapName, nsName), actualConfigMap)
+	assert.Equal(t, checkup.NewConfigMap(nsName, expectedConfigMapName), actualConfigMap)
 }
 
 func assertConfigMapWriterRoleCreated(t *testing.T, testClient *fake.Clientset, nsName, configMapName, roleName string) {

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -618,7 +618,7 @@ func assertServiceAccountCreated(t *testing.T, testClient *fake.Clientset, nsNam
 	actualServiceAccount, err := testClient.Tracker().Get(gvr, nsName, serviceAccountName)
 
 	assert.NoError(t, err)
-	assert.Equal(t, checkup.NewServiceAccount(serviceAccountName, nsName), actualServiceAccount)
+	assert.Equal(t, checkup.NewServiceAccount(nsName, serviceAccountName), actualServiceAccount)
 }
 
 func assertResultsConfigMapCreated(t *testing.T, testClient *fake.Clientset, nsName, expectedConfigMapName string) {

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -635,7 +635,7 @@ func assertConfigMapWriterRoleCreated(t *testing.T, testClient *fake.Clientset, 
 
 	assert.NoError(t, err)
 
-	expectedRole := checkup.NewConfigMapWriterRole(roleName, nsName, configMapName)
+	expectedRole := checkup.NewConfigMapWriterRole(nsName, roleName, configMapName)
 
 	assert.Equal(t, expectedRole, actualRole)
 }


### PR DESCRIPTION
In order to be aligned with the rest of the code,
the namespace name parameter should be first and the object name second.

Signed-off-by: Orel Misan <omisan@redhat.com>

~~This PR depends on PR #133.~~