### PR TITLE
checkup: Use Subject to create ClusterRoleBindings

### DIFF
--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -662,8 +662,10 @@ func assertClusterRoleBindingsCreated(
 	actualClusterRoleBindings, err := testClient.listClusterRoleBindings()
 	assert.NoError(t, err)
 
+	serviceAccountSubject := checkup.NewServiceAccountSubject(nsName, serviceAccountName)
+
 	var expectedClusterRoleBindings []rbacv1.ClusterRoleBinding
-	for _, clusterRoleBindingPtr := range checkup.NewClusterRoleBindings(clusterRoles, nsName, serviceAccountName, nameGen) {
+	for _, clusterRoleBindingPtr := range checkup.NewClusterRoleBindings(clusterRoles, serviceAccountSubject, nameGen) {
 		expectedClusterRoleBindings = append(expectedClusterRoleBindings, *clusterRoleBindingPtr)
 	}
 	assert.Equal(t, actualClusterRoleBindings, expectedClusterRoleBindings)

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -646,8 +646,8 @@ func assertConfigMapWriterRoleBindingCreated(t *testing.T, testClient *fake.Clie
 
 	assert.NoError(t, err)
 
-	subject := rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: serviceAccountName, Namespace: nsName}
-	expectedRoleBinding := checkup.NewRoleBinding(nsName, roleName, subject)
+	serviceAccountSubject := checkup.NewServiceAccountSubject(nsName, serviceAccountName)
+	expectedRoleBinding := checkup.NewRoleBinding(nsName, roleName, serviceAccountSubject)
 
 	assert.Equal(t, expectedRoleBinding, actualRoleBinding)
 }


### PR DESCRIPTION
Currently, there is a serviceAccountSubject used for creating RoleBinding objects.
Use it to create ClusterRoleBinding objects as well.

Signed-off-by: Orel Misan <omisan@redhat.com>

This PR depends on PR #134.