### PR TITLE
checkup, tests: Update assertConfigMapWriterRoleBindingCreated()

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -76,7 +76,7 @@ func New(c kubernetes.Interface, checkupConfig *config.Config, namer namer) *Che
 	subject := newServiceAccountSubject(nsName, ServiceAccountName)
 	var checkupRoleBindings []*rbacv1.RoleBinding
 	for _, role := range checkupRoles {
-		checkupRoleBindings = append(checkupRoleBindings, NewRoleBinding(role.Name, nsName, subject))
+		checkupRoleBindings = append(checkupRoleBindings, NewRoleBinding(nsName, role.Name, subject))
 	}
 
 	checkupEnvVars := []corev1.EnvVar{
@@ -232,7 +232,7 @@ func newConfigMapWriterPolicyRule(cmName string) rbacv1.PolicyRule {
 	}
 }
 
-func NewRoleBinding(roleName, namespaceName string, subject rbacv1.Subject) *rbacv1.RoleBinding {
+func NewRoleBinding(namespaceName, roleName string, subject rbacv1.Subject) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: rbacv1.GroupName},
 		ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: namespaceName},

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -90,7 +90,7 @@ func New(c kubernetes.Interface, checkupConfig *config.Config, namer namer) *Che
 		client:              c,
 		teardownTimeout:     defaultTeardownTimeout,
 		namespace:           NewNamespace(nsName),
-		serviceAccount:      NewServiceAccount(ServiceAccountName, nsName),
+		serviceAccount:      NewServiceAccount(nsName, ServiceAccountName),
 		resultConfigMap:     NewConfigMap(ResultsConfigMapName, nsName),
 		roles:               checkupRoles,
 		roleBindings:        checkupRoleBindings,
@@ -195,7 +195,7 @@ func NewNamespace(name string) *corev1.Namespace {
 	}
 }
 
-func NewServiceAccount(name, namespaceName string) *corev1.ServiceAccount {
+func NewServiceAccount(namespaceName, name string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespaceName},
 	}

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -201,6 +201,14 @@ func NewServiceAccount(name, namespaceName string) *corev1.ServiceAccount {
 	}
 }
 
+func newServiceAccountSubject(serviceAccountName, serviceAccountNamespace string) rbacv1.Subject {
+	return rbacv1.Subject{
+		Kind:      rbacv1.ServiceAccountKind,
+		Name:      serviceAccountName,
+		Namespace: serviceAccountNamespace,
+	}
+}
+
 func NewConfigMap(name, namespaceName string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespaceName},
@@ -245,14 +253,6 @@ func NewClusterRoleBindings(
 		clusterRoleBindings = append(clusterRoleBindings, newClusterRoleBinding(clusterRoleBindingName, clusterRole.Name, subject))
 	}
 	return clusterRoleBindings
-}
-
-func newServiceAccountSubject(serviceAccountName, serviceAccountNamespace string) rbacv1.Subject {
-	return rbacv1.Subject{
-		Kind:      rbacv1.ServiceAccountKind,
-		Name:      serviceAccountName,
-		Namespace: serviceAccountNamespace,
-	}
 }
 
 func newClusterRoleBinding(name, clusterRoleName string, subject rbacv1.Subject) *rbacv1.ClusterRoleBinding {

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -91,7 +91,7 @@ func New(c kubernetes.Interface, checkupConfig *config.Config, namer namer) *Che
 		teardownTimeout:     defaultTeardownTimeout,
 		namespace:           NewNamespace(nsName),
 		serviceAccount:      NewServiceAccount(nsName, ServiceAccountName),
-		resultConfigMap:     NewConfigMap(ResultsConfigMapName, nsName),
+		resultConfigMap:     NewConfigMap(nsName, ResultsConfigMapName),
 		roles:               checkupRoles,
 		roleBindings:        checkupRoleBindings,
 		jobTimeout:          checkupConfig.Timeout,
@@ -209,7 +209,7 @@ func newServiceAccountSubject(serviceAccountNamespace, serviceAccountName string
 	}
 }
 
-func NewConfigMap(name, namespaceName string) *corev1.ConfigMap {
+func NewConfigMap(namespaceName, name string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespaceName},
 	}

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -95,7 +95,7 @@ func New(c kubernetes.Interface, checkupConfig *config.Config, namer namer) *Che
 		roles:               checkupRoles,
 		roleBindings:        checkupRoleBindings,
 		jobTimeout:          checkupConfig.Timeout,
-		clusterRoleBindings: NewClusterRoleBindings(checkupConfig.ClusterRoles, ServiceAccountName, nsName, namer),
+		clusterRoleBindings: NewClusterRoleBindings(checkupConfig.ClusterRoles, nsName, ServiceAccountName, namer),
 		job: NewCheckupJob(
 			JobName,
 			nsName,
@@ -243,8 +243,8 @@ func NewRoleBinding(namespaceName, roleName string, subject rbacv1.Subject) *rba
 
 func NewClusterRoleBindings(
 	clusterRoles []*rbacv1.ClusterRole,
-	serviceAccountName,
-	serviceAccountNs string,
+	serviceAccountNs,
+	serviceAccountName string,
 	namer namer) []*rbacv1.ClusterRoleBinding {
 	subject := newServiceAccountSubject(serviceAccountNs, serviceAccountName)
 	var clusterRoleBindings []*rbacv1.ClusterRoleBinding

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -73,7 +73,7 @@ func New(c kubernetes.Interface, checkupConfig *config.Config, namer namer) *Che
 	nsName := namer.Name(NamespaceName)
 	checkupRoles := []*rbacv1.Role{NewConfigMapWriterRole(ResultsConfigMapWriterRoleName, nsName, ResultsConfigMapName)}
 
-	subject := newServiceAccountSubject(ServiceAccountName, nsName)
+	subject := newServiceAccountSubject(nsName, ServiceAccountName)
 	var checkupRoleBindings []*rbacv1.RoleBinding
 	for _, role := range checkupRoles {
 		checkupRoleBindings = append(checkupRoleBindings, NewRoleBinding(role.Name, nsName, subject))
@@ -201,7 +201,7 @@ func NewServiceAccount(namespaceName, name string) *corev1.ServiceAccount {
 	}
 }
 
-func newServiceAccountSubject(serviceAccountName, serviceAccountNamespace string) rbacv1.Subject {
+func newServiceAccountSubject(serviceAccountNamespace, serviceAccountName string) rbacv1.Subject {
 	return rbacv1.Subject{
 		Kind:      rbacv1.ServiceAccountKind,
 		Name:      serviceAccountName,
@@ -246,7 +246,7 @@ func NewClusterRoleBindings(
 	serviceAccountName,
 	serviceAccountNs string,
 	namer namer) []*rbacv1.ClusterRoleBinding {
-	subject := newServiceAccountSubject(serviceAccountName, serviceAccountNs)
+	subject := newServiceAccountSubject(serviceAccountNs, serviceAccountName)
 	var clusterRoleBindings []*rbacv1.ClusterRoleBinding
 	for _, clusterRole := range clusterRoles {
 		clusterRoleBindingName := namer.Name(clusterRole.Name)

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -71,7 +71,7 @@ type namer interface {
 
 func New(c kubernetes.Interface, checkupConfig *config.Config, namer namer) *Checkup {
 	nsName := namer.Name(NamespaceName)
-	checkupRoles := []*rbacv1.Role{NewConfigMapWriterRole(ResultsConfigMapWriterRoleName, nsName, ResultsConfigMapName)}
+	checkupRoles := []*rbacv1.Role{NewConfigMapWriterRole(nsName, ResultsConfigMapWriterRoleName, ResultsConfigMapName)}
 
 	subject := newServiceAccountSubject(nsName, ServiceAccountName)
 	var checkupRoleBindings []*rbacv1.RoleBinding
@@ -215,7 +215,7 @@ func NewConfigMap(namespaceName, name string) *corev1.ConfigMap {
 	}
 }
 
-func NewConfigMapWriterRole(name, namespaceName, configMapName string) *rbacv1.Role {
+func NewConfigMapWriterRole(namespaceName, name, configMapName string) *rbacv1.Role {
 	return &rbacv1.Role{
 		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: rbacv1.GroupName},
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespaceName},

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -97,8 +97,8 @@ func New(c kubernetes.Interface, checkupConfig *config.Config, namer namer) *Che
 		jobTimeout:          checkupConfig.Timeout,
 		clusterRoleBindings: NewClusterRoleBindings(checkupConfig.ClusterRoles, nsName, ServiceAccountName, namer),
 		job: NewCheckupJob(
-			JobName,
 			nsName,
+			JobName,
 			ServiceAccountName,
 			checkupConfig.Image,
 			int64(checkupConfig.Timeout.Seconds()),
@@ -268,7 +268,7 @@ func newClusterRoleBinding(name, clusterRoleName string, subject rbacv1.Subject)
 	}
 }
 
-func NewCheckupJob(name, namespaceName, serviceAccountName, image string, activeDeadlineSeconds int64, envs []corev1.EnvVar) *batchv1.Job {
+func NewCheckupJob(namespaceName, name, serviceAccountName, image string, activeDeadlineSeconds int64, envs []corev1.EnvVar) *batchv1.Job {
 	const containerName = "checkup"
 
 	checkupContainer := corev1.Container{Name: containerName, Image: image, Env: envs}

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -166,10 +166,6 @@ func (c *Checkup) Results() (results.Results, error) {
 	return results.ReadFromConfigMap(c.client, c.resultConfigMap.Namespace, c.resultConfigMap.Name)
 }
 
-func (c *Checkup) SetTeardownTimeout(duration time.Duration) {
-	c.teardownTimeout = duration
-}
-
 func (c *Checkup) Teardown() error {
 	const errPrefix = "teardown"
 	var errs []error
@@ -187,6 +183,10 @@ func (c *Checkup) Teardown() error {
 	}
 
 	return nil
+}
+
+func (c *Checkup) SetTeardownTimeout(duration time.Duration) {
+	c.teardownTimeout = duration
 }
 
 func NewNamespace(name string) *corev1.Namespace {

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -627,8 +627,8 @@ func assertConfigMapWriterRoleBindingCreated(t *testing.T, testClient *fake.Clie
 
 	assert.NoError(t, err)
 
-	subject := rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: checkup.ServiceAccountName, Namespace: nsName}
-	expectedRoleBinding := checkup.NewRoleBinding(nsName, checkup.ResultsConfigMapWriterRoleName, subject)
+	serviceAccountSubject := checkup.NewServiceAccountSubject(nsName, checkup.ServiceAccountName)
+	expectedRoleBinding := checkup.NewRoleBinding(nsName, checkup.ResultsConfigMapWriterRoleName, serviceAccountSubject)
 
 	assert.Equal(t, expectedRoleBinding, actualRoleBinding)
 }

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -607,7 +607,7 @@ func assertResultsConfigMapCreated(t *testing.T, testClient *fake.Clientset, nsN
 	actualConfigMap, err := testClient.Tracker().Get(gvr, nsName, checkup.ResultsConfigMapName)
 
 	assert.NoError(t, err)
-	assert.Equal(t, checkup.NewConfigMap(checkup.ResultsConfigMapName, nsName), actualConfigMap)
+	assert.Equal(t, checkup.NewConfigMap(nsName, checkup.ResultsConfigMapName), actualConfigMap)
 }
 
 func assertConfigMapWriterRoleCreated(t *testing.T, testClient *fake.Clientset, nsName string) {

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -642,8 +642,10 @@ func assertClusterRoleBindingsCreated(
 	actualClusterRoleBindings, err := testClient.listClusterRoleBindings()
 	assert.NoError(t, err)
 
+	serviceAccountSubject := checkup.NewServiceAccountSubject(nsName, checkup.ServiceAccountName)
+
 	var expectedClusterRoleBindings []rbacv1.ClusterRoleBinding
-	for _, clusterRoleBindingPtr := range checkup.NewClusterRoleBindings(clusterRoles, nsName, checkup.ServiceAccountName, nameGen) {
+	for _, clusterRoleBindingPtr := range checkup.NewClusterRoleBindings(clusterRoles, serviceAccountSubject, nameGen) {
 		expectedClusterRoleBindings = append(expectedClusterRoleBindings, *clusterRoleBindingPtr)
 	}
 	assert.Equal(t, actualClusterRoleBindings, expectedClusterRoleBindings)

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -599,7 +599,7 @@ func assertServiceAccountCreated(t *testing.T, testClient *fake.Clientset, nsNam
 	actualServiceAccount, err := testClient.Tracker().Get(gvr, nsName, checkup.ServiceAccountName)
 
 	assert.NoError(t, err)
-	assert.Equal(t, checkup.NewServiceAccount(checkup.ServiceAccountName, nsName), actualServiceAccount)
+	assert.Equal(t, checkup.NewServiceAccount(nsName, checkup.ServiceAccountName), actualServiceAccount)
 }
 
 func assertResultsConfigMapCreated(t *testing.T, testClient *fake.Clientset, nsName string) {

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -643,7 +643,7 @@ func assertClusterRoleBindingsCreated(
 	assert.NoError(t, err)
 
 	var expectedClusterRoleBindings []rbacv1.ClusterRoleBinding
-	for _, clusterRoleBindingPtr := range checkup.NewClusterRoleBindings(clusterRoles, checkup.ServiceAccountName, nsName, nameGen) {
+	for _, clusterRoleBindingPtr := range checkup.NewClusterRoleBindings(clusterRoles, nsName, checkup.ServiceAccountName, nameGen) {
 		expectedClusterRoleBindings = append(expectedClusterRoleBindings, *clusterRoleBindingPtr)
 	}
 	assert.Equal(t, actualClusterRoleBindings, expectedClusterRoleBindings)

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -628,7 +628,7 @@ func assertConfigMapWriterRoleBindingCreated(t *testing.T, testClient *fake.Clie
 	assert.NoError(t, err)
 
 	subject := rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: checkup.ServiceAccountName, Namespace: nsName}
-	expectedRoleBinding := checkup.NewRoleBinding(checkup.ResultsConfigMapWriterRoleName, nsName, subject)
+	expectedRoleBinding := checkup.NewRoleBinding(nsName, checkup.ResultsConfigMapWriterRoleName, subject)
 
 	assert.Equal(t, expectedRoleBinding, actualRoleBinding)
 }

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -307,7 +307,7 @@ func TestCheckupRunShouldCreateAJob(t *testing.T) {
 			}
 			expectedEnvVars = append(expectedEnvVars, testCase.envVars...)
 			expectedJob := checkup.NewCheckupJob(
-				checkup.JobName, checkupNamespaceName, checkup.ServiceAccountName, testImage, int64(testTimeout.Seconds()), expectedEnvVars)
+				checkupNamespaceName, checkup.JobName, checkup.ServiceAccountName, testImage, int64(testTimeout.Seconds()), expectedEnvVars)
 			actualJob, err := testClient.BatchV1().Jobs(checkupNamespaceName).Get(context.Background(), checkup.JobName, metav1.GetOptions{})
 			assert.NoError(t, err)
 

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -616,8 +616,7 @@ func assertConfigMapWriterRoleCreated(t *testing.T, testClient *fake.Clientset, 
 
 	assert.NoError(t, err)
 
-	expectedRole := checkup.NewConfigMapWriterRole(
-		checkup.ResultsConfigMapWriterRoleName, nsName, checkup.ResultsConfigMapName)
+	expectedRole := checkup.NewConfigMapWriterRole(nsName, checkup.ResultsConfigMapWriterRoleName, checkup.ResultsConfigMapName)
 
 	assert.Equal(t, expectedRole, actualRole)
 }


### PR DESCRIPTION
Use checkup.NewServiceAccountSubject() instead of a struct literal.

Signed-off-by: Orel Misan <omisan@redhat.com>

This PR depends on PR #135.