### PR TITLE
gotestsuite: Introduce a test suite structure for tests

### DIFF
--- a/kiagnose/internal/checkup/suite_test.go
+++ b/kiagnose/internal/checkup/suite_test.go
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package checkup_test
+
+import (
+	"testing"
+
+	suite "github.com/kiagnose/kiagnose/kiagnose/internal/gotestsuite"
+)
+
+type checkupSuite struct {
+	suite.Suite
+	tClient *testsClient
+}
+
+func NewCheckupSuite(t *testing.T) *checkupSuite {
+	s := &checkupSuite{
+		Suite: *suite.NewSuite(t),
+	}
+
+	s.AddSetupFixture("Reset Test Client", func(t *testing.T) {
+		s.tClient = nil
+	}, suite.FixtureOptions{AutoRun: true})
+
+	return s
+}
+
+func (cs *checkupSuite) Test(name string, f func(*testing.T, *testsClient), fixture ...string) {
+	cs.Suite.Test(name, func(t *testing.T) {
+		if cs.tClient == nil {
+			panic("Test Client is not set")
+		}
+		f(t, cs.tClient)
+	}, fixture...)
+}
+
+func (cs *checkupSuite) SetClient(c *testsClient) {
+	cs.tClient = c
+}

--- a/kiagnose/internal/gotestsuite/suite.go
+++ b/kiagnose/internal/gotestsuite/suite.go
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package gotestsuite
+
+import "testing"
+
+type Suite struct {
+	t                   *testing.T
+	fixtures            map[string]func(*testing.T)
+	autoRunTestFixtures []func(*testing.T)
+}
+
+type FixtureOptions struct {
+	AutoRun bool
+}
+
+func NewSuite(t *testing.T) *Suite {
+	return &Suite{
+		t:        t,
+		fixtures: map[string]func(*testing.T){},
+	}
+}
+
+func (s *Suite) AddSetupFixture(id string, f func(*testing.T), options FixtureOptions) {
+	if _, ok := s.fixtures[id]; ok {
+		panic("Fixture already exists: " + id)
+	}
+
+	if options.AutoRun {
+		s.autoRunTestFixtures = append(s.autoRunTestFixtures, f)
+	} else {
+		s.fixtures[id] = f
+	}
+}
+
+func (s *Suite) Test(name string, f func(*testing.T), fixture ...string) {
+	var fixtureFuncs []func(*testing.T)
+
+	for _, fixtureName := range fixture {
+		fixtureFunc, ok := s.fixtures[fixtureName]
+		if !ok {
+			panic("Fixture does not exist: " + fixtureName)
+		}
+		fixtureFuncs = append(fixtureFuncs, fixtureFunc)
+	}
+
+	s.t.Run(name, func(t *testing.T) {
+		for _, setup := range s.autoRunTestFixtures {
+			setup(t)
+		}
+		for _, setup := range fixtureFuncs {
+			setup(t)
+		}
+		f(t)
+	})
+}


### PR DESCRIPTION
The test suite is providing a structure to write tests.
One is able to add fixtures (currently for setup only) and ref
them from the test itself in case it is needed.

Some fixtures may be added and instructed to run before each test,
without the need to ref them explicitly from the tests.

The checkup teardown tests are adjusted to use the new suite.