### PR TITLE
checkup: Move teardown logic to a dedicated method

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -274,6 +274,10 @@ func (c *Checkup) SetTeardownTimeout(duration time.Duration) {
 }
 
 func (c *Checkup) Teardown() error {
+	return c.teardownWithEphemeralNamespace()
+}
+
+func (c *Checkup) teardownWithEphemeralNamespace() error {
 	const errPrefix = "teardown"
 	var errs []error
 


### PR DESCRIPTION
The teardown sequence when using an ephemeral namespace is different from when using a target namespace.

Move the existing teardown logic of ephemeral namespace to a dedicated method.

Signed-off-by: Orel Misan <omisan@redhat.com>