### PR TITLE
checkup: Introduce target Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 A checkup is a containerized application, which checks that a certain cluster functionality is working.
 A checkup can be provided by a third party vendor, and should adhere to the Kiagnose checkup API.
 
-Kiagnose runs each checkup in a dedicated ephemeral Namespace, which is disposed when the checkup ends.
+Kiagnose can execute a checkup in:
+1. An existing Namespace.
+2. A dedicated ephemeral Namespace, which is disposed when the checkup finishes.
+
 Kiagnose passes user-supplied configuration to the checkup, and reports the checkup's results upon termination.
 
 # Usage
@@ -44,7 +47,8 @@ Kiagnose will **AUTOMATICALLY** bind these permissions to the checkup instance.
 The main user-interface is a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) object with a
 certain structure.
 
-The ConfigMap object is created in the `kiagnose` Namespace (created during Kiagnose installation).
+In order to execute a checkup in an existing namespace, create the ConfigMap object in it.
+In order to execute a checkup in an ephemeral namespace create the ConfigMap object in the `kiagnose` Namespace (created during Kiagnose installation).
 
 ### Input Fields
 The user can configure the following under the `data` field:
@@ -63,7 +67,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-checkup-config
-  namespace: kiagnose
+  namespace: <target namespace>
 data:
   spec.image: my-registry/example-checkup:main
   spec.timeout: 5m
@@ -106,7 +110,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: CONFIGMAP_NAMESPACE
-              value: kiagnose
+              value: <target namespace>
             - name: CONFIGMAP_NAME
               value: example-checkup-config
 ```
@@ -117,7 +121,7 @@ The Kiagnose Job waits until the checkup Job is completed or timed-out.
 After the Kiagnose Job had completed, the results are made available at the user-supplied ConfigMap object:
 
 ```bash
-kubectl get configmap example-checkup-config -n kiagnose -o yaml
+kubectl get configmap example-checkup-config -n <target-namespace> -o yaml
 ```
 ### Output Fields
 | Property                   | Description                                         | Mandatory | Remarks |
@@ -134,7 +138,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-checkup-config
-  namespace: kiagnose
+  namespace: <target-namespace>
 data:
   spec.image: my-registry/example-checkup:main
   spec.timeout: 5m
@@ -159,7 +163,7 @@ kubectl logs job.batch/<Kiagnose-job-name> -n kiagnose
 Remove the Kiagnose Job and the ConfigMap object when the logs and the results are no longer needed:
 ```bash
 kubectl delete job.batch/<Kiagnose-job-name> -n kiagnose
-kubectl delete configmap <ConfigMap name> -n kiagnose
+kubectl delete configmap <ConfigMap name> -n <target-namespace>
 ```
 
 ## Checkup Removal

--- a/checkups/echo/README.md
+++ b/checkups/echo/README.md
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: echo-checkup-config
-  namespace: kiagnose
+  namespace: <target-namespace>
 data:
   spec.image: quay.io/kiagnose/echo-checkup:main
   spec.timeout: 1m
@@ -54,7 +54,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: CONFIGMAP_NAMESPACE
-              value: kiagnose
+              value: <target-namespace>
             - name: CONFIGMAP_NAME
               value: echo-checkup-config
 EOF
@@ -68,7 +68,7 @@ kubectl wait --for=condition=complete --timeout=70s job/echo-checkup1 -n kiagnos
 ### Results Retrieval
 After the Kiagnose Job had completed, retrieve the user-supplied `ConfigMap` to get the results:
 ```bash
-kubectl get configmap echo-checkup-config -n kiagnose -o yaml
+kubectl get configmap echo-checkup-config -n <target-namespace> -o yaml
 ```
 
 In a success scenario, the following results are expected:
@@ -102,7 +102,7 @@ kind: ConfigMap
 metadata:
   creationTimestamp: "2022-06-06T10:59:56Z"
   name: echo-checkup-config
-  namespace: kiagnose
+  namespace: <target-namespace>
   resourceVersion: "557"
   uid: e00b801c-3055-4c3c-9dc5-8a944f01d9de
 ```
@@ -110,7 +110,7 @@ metadata:
 Remove the Kiagnose Job and the ConfigMap object when the logs and the results are no longer needed:
 ```bash
 kubectl delete job.batch/echo-checkup1 -n kiagnose
-kubectl delete configmap echo-checkup-config -n kiagnose
+kubectl delete configmap echo-checkup-config -n <target-namespace>
 ```
 
 ## API

--- a/checkups/kubevirt-vm-latency/README.md
+++ b/checkups/kubevirt-vm-latency/README.md
@@ -57,7 +57,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubevirt-vm-latency-checkup-config
-  namespace: kiagnose
+  namespace: <target-namespace>
 data:
   spec.image: quay.io/kiagnose/kubevirt-vm-latency:main
   spec.timeout: 5m
@@ -92,7 +92,7 @@ spec:
           image: quay.io/kiagnose/kiagnose:main
           env:
             - name: CONFIGMAP_NAMESPACE
-              value: kiagnose
+              value: <target-namespace>
             - name: CONFIGMAP_NAME
               value: kubevirt-vm-latency-checkup-config
 EOF
@@ -110,14 +110,14 @@ kubectl wait job kubevirt-vm-latency-checkup -n kiagnose --for condition=complet
 ### Example
 Retrieve the checkup results:
 ```bash
-kubectl get configmap kubevirt-vm-latency-checkup-config -n kiagnose -o yaml
+kubectl get configmap kubevirt-vm-latency-checkup-config -n <target-namespace> -o yaml
 ```
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubevirt-vm-latency-checkup-config
-  namespace: kiagnose
+  namespace: <target-namespace>
 data:
   spec.image: quay.io/kiagnose/kubevirt-vm-latency:main
   spec.timeout: 5m
@@ -173,7 +173,7 @@ status.failureReason: "run: failed to run check: failed due to connectivity issu
 ## Clean up
 ```bash
 kubectl delete job -n kiagnose kubevirt-vm-latency-checkup
-kubectl delete config-map -n kubevirt-vm-latency-checkup-config
+kubectl delete config-map -n <target-namespace> kubevirt-vm-latency-checkup-config
 ```
 Once the checkup is finished it's safe to remove the ClusterRole:
 ```bash

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -324,6 +324,10 @@ func (c *Checkup) teardownWithTargetNamespace() error {
 		errs = append(errs, err)
 	}
 
+	if err := serviceaccount.Delete(c.client, c.serviceAccount.Namespace, c.serviceAccount.Name); err != nil {
+		errs = append(errs, err)
+	}
+
 	if len(errs) > 0 {
 		const errPrefix = "teardown"
 		return fmt.Errorf("%s: %v", errPrefix, concentrateErrors(errs))

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -332,6 +332,10 @@ func (c *Checkup) teardownWithTargetNamespace() error {
 		errs = append(errs, err)
 	}
 
+	if err := configmap.Delete(c.client, c.resultConfigMap.Namespace, c.resultConfigMap.Name); err != nil {
+		errs = append(errs, err)
+	}
+
 	if len(errs) > 0 {
 		const errPrefix = "teardown"
 		return fmt.Errorf("%s: %v", errPrefix, concentrateErrors(errs))

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -328,6 +328,10 @@ func (c *Checkup) teardownWithTargetNamespace() error {
 		errs = append(errs, err)
 	}
 
+	if err := rbac.DeleteRoles(c.client, c.roles); err != nil {
+		errs = append(errs, err)
+	}
+
 	if len(errs) > 0 {
 		const errPrefix = "teardown"
 		return fmt.Errorf("%s: %v", errPrefix, concentrateErrors(errs))

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -320,6 +320,10 @@ func (c *Checkup) teardownWithTargetNamespace() error {
 		errs = append(errs, err)
 	}
 
+	if err := rbac.DeleteRoleBindings(c.client, c.roleBindings); err != nil {
+		errs = append(errs, err)
+	}
+
 	if len(errs) > 0 {
 		const errPrefix = "teardown"
 		return fmt.Errorf("%s: %v", errPrefix, concentrateErrors(errs))

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -287,7 +287,7 @@ func (c *Checkup) Teardown() error {
 		return c.teardownWithEphemeralNamespace()
 	}
 
-	return nil
+	return c.teardownWithTargetNamespace()
 }
 
 func (c *Checkup) teardownWithEphemeralNamespace() error {
@@ -304,6 +304,15 @@ func (c *Checkup) teardownWithEphemeralNamespace() error {
 
 	if len(errs) > 0 {
 		return fmt.Errorf("%s: %v", errPrefix, concentrateErrors(errs))
+	}
+
+	return nil
+}
+
+func (c *Checkup) teardownWithTargetNamespace() error {
+	if err := job.DeleteAndWait(c.client, c.job, c.teardownTimeout); err != nil {
+		const errPrefix = "teardown"
+		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
 	return nil

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -287,6 +287,9 @@ func TestTeardownInTargetNamespaceShouldSucceed(t *testing.T) {
 
 	configMapWriterRoleName := checkup.NameResultsConfigMapWriterRole(testCheckupName)
 	assertConfigMapWriterRoleDoesntExists(t, testClient.Clientset, testTargetNs, configMapWriterRoleName)
+
+	resultsConfigMapName := checkup.NameResultsConfigMap(testCheckupName)
+	assertConfigMapDoesntExists(t, testClient.Clientset, testTargetNs, resultsConfigMapName)
 }
 
 func TestCheckupTeardownShouldFail(t *testing.T) {
@@ -838,6 +841,13 @@ func assertResultsConfigMapCreated(t *testing.T, testClient *fake.Clientset, nsN
 
 	assert.NoError(t, err)
 	assert.Equal(t, checkup.NewConfigMap(nsName, expectedConfigMapName), actualConfigMap)
+}
+
+func assertConfigMapDoesntExists(t *testing.T, testClient *fake.Clientset, nsName, expectedConfigMapName string) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: configMapResource}
+	_, err := testClient.Tracker().Get(gvr, nsName, expectedConfigMapName)
+
+	assert.ErrorContains(t, err, "not found")
 }
 
 func assertConfigMapWriterRoleCreated(t *testing.T, testClient *fake.Clientset, nsName, configMapName, roleName string) {

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -281,6 +281,9 @@ func TestTeardownInTargetNamespaceShouldSucceed(t *testing.T) {
 	assertCheckupJobDoesntExists(t, testClient, testTargetNs, checkupJobName)
 	assertNoClusterRoleBindingExists(t, testClient)
 	assertNoRoleBindingExists(t, testClient)
+
+	serviceAccountName := checkup.NameServiceAccount(testCheckupName)
+	assertServiceAccountDoesntExists(t, testClient.Clientset, testTargetNs, serviceAccountName)
 }
 
 func TestCheckupTeardownShouldFail(t *testing.T) {
@@ -817,6 +820,13 @@ func assertServiceAccountCreated(t *testing.T, testClient *fake.Clientset, nsNam
 
 	assert.NoError(t, err)
 	assert.Equal(t, checkup.NewServiceAccount(nsName, serviceAccountName), actualServiceAccount)
+}
+
+func assertServiceAccountDoesntExists(t *testing.T, testClient *fake.Clientset, nsName, serviceAccountName string) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: serviceAccountResource}
+	_, err := testClient.Tracker().Get(gvr, nsName, serviceAccountName)
+
+	assert.ErrorContains(t, err, "not found")
 }
 
 func assertResultsConfigMapCreated(t *testing.T, testClient *fake.Clientset, nsName, expectedConfigMapName string) {

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -262,7 +262,7 @@ func TestTeardownInTargetNamespaceShouldSucceed(t *testing.T) {
 		testClient,
 		testTargetNs,
 		testCheckupName,
-		&config.Config{Image: testImage, Timeout: testTimeout},
+		&config.Config{Image: testImage, Timeout: testTimeout, ClusterRoles: newTestClusterRoles()},
 		nameGen,
 	)
 
@@ -278,6 +278,7 @@ func TestTeardownInTargetNamespaceShouldSucceed(t *testing.T) {
 
 	assertNamespaceExists(t, testClient.Clientset, testTargetNs)
 	assertCheckupJobDoesntExists(t, testClient, testTargetNs, checkupJobName)
+	assertNoClusterRoleBindingExists(t, testClient)
 }
 
 func TestCheckupTeardownShouldFail(t *testing.T) {

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -284,6 +284,9 @@ func TestTeardownInTargetNamespaceShouldSucceed(t *testing.T) {
 
 	serviceAccountName := checkup.NameServiceAccount(testCheckupName)
 	assertServiceAccountDoesntExists(t, testClient.Clientset, testTargetNs, serviceAccountName)
+
+	configMapWriterRoleName := checkup.NameResultsConfigMapWriterRole(testCheckupName)
+	assertConfigMapWriterRoleDoesntExists(t, testClient.Clientset, testTargetNs, configMapWriterRoleName)
 }
 
 func TestCheckupTeardownShouldFail(t *testing.T) {
@@ -846,6 +849,13 @@ func assertConfigMapWriterRoleCreated(t *testing.T, testClient *fake.Clientset, 
 	expectedRole := checkup.NewConfigMapWriterRole(nsName, roleName, configMapName)
 
 	assert.Equal(t, expectedRole, actualRole)
+}
+
+func assertConfigMapWriterRoleDoesntExists(t *testing.T, testClient *fake.Clientset, nsName, roleName string) {
+	gvr := schema.GroupVersionResource{Group: rbacv1.GroupName, Version: "v1", Resource: rolesResource}
+	_, err := testClient.Tracker().Get(gvr, nsName, roleName)
+
+	assert.ErrorContains(t, err, "not found")
 }
 
 func assertConfigMapWriterRoleBindingCreated(t *testing.T, testClient *fake.Clientset, nsName, roleName, serviceAccountName string) {

--- a/kiagnose/internal/checkup/serviceaccount/serviceaccount.go
+++ b/kiagnose/internal/checkup/serviceaccount/serviceaccount.go
@@ -38,3 +38,7 @@ func Create(client kubernetes.Interface, sa *corev1.ServiceAccount) (*corev1.Ser
 
 	return createdSa, nil
 }
+
+func Delete(client kubernetes.Interface, namespace, name string) error {
+	return client.CoreV1().ServiceAccounts(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+}

--- a/kiagnose/internal/configmap/configmap.go
+++ b/kiagnose/internal/configmap/configmap.go
@@ -44,3 +44,7 @@ func Get(client kubernetes.Interface, namespace, name string) (*corev1.ConfigMap
 func Update(client kubernetes.Interface, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 	return client.CoreV1().ConfigMaps(configMap.Namespace).Update(context.Background(), configMap, metav1.UpdateOptions{})
 }
+
+func Delete(client kubernetes.Interface, namespace, name string) error {
+	return client.CoreV1().ConfigMaps(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+}

--- a/kiagnose/internal/rbac/rbac.go
+++ b/kiagnose/internal/rbac/rbac.go
@@ -229,3 +229,33 @@ func createRoleBinding(client kubernetes.Interface, crb *rbacv1.RoleBinding) (*r
 
 	return createdRb, nil
 }
+
+func DeleteRoleBindings(client kubernetes.Interface, roleBindings []*rbacv1.RoleBinding) error {
+	var errs []error
+
+	for _, roleBinding := range roleBindings {
+		if err := deleteRoleBinding(client, roleBinding.Namespace, roleBinding.Name); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%v", concentrateErrors(errs))
+	}
+
+	return nil
+}
+
+func deleteRoleBinding(client kubernetes.Interface, namespace, name string) error {
+	return client.RbacV1().RoleBindings(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
+func concentrateErrors(errs []error) error {
+	sb := strings.Builder{}
+	for _, err := range errs {
+		sb.WriteString(err.Error())
+		sb.WriteString("\n")
+	}
+
+	return errors.New(sb.String())
+}

--- a/kiagnose/internal/rbac/rbac.go
+++ b/kiagnose/internal/rbac/rbac.go
@@ -207,6 +207,26 @@ func createRole(client kubernetes.Interface, role *rbacv1.Role) (*rbacv1.Role, e
 	return createdRole, nil
 }
 
+func DeleteRoles(client kubernetes.Interface, roles []*rbacv1.Role) error {
+	var errs []error
+
+	for _, role := range roles {
+		if err := deleteRole(client, role.Namespace, role.Name); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%v", concentrateErrors(errs))
+	}
+
+	return nil
+}
+
+func deleteRole(client kubernetes.Interface, namespace, name string) error {
+	return client.RbacV1().Roles(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
 func CreateRoleBindings(client kubernetes.Interface, bindings []*rbacv1.RoleBinding) ([]*rbacv1.RoleBinding, error) {
 	var createdRoleBindings []*rbacv1.RoleBinding
 	for _, roleBinding := range bindings {

--- a/kiagnose/mainflow.go
+++ b/kiagnose/mainflow.go
@@ -45,7 +45,7 @@ func Run(env map[string]string) error {
 	}
 
 	l := launcher.New(
-		checkup.New(c, configMapName, checkupConfig, namegenerator.NameGenerator{}),
+		checkup.New(c, configMapNamespace, configMapName, checkupConfig, namegenerator.NameGenerator{}),
 		reporter.New(c, configMapNamespace, configMapName),
 	)
 

--- a/manifests/kiagnose.yaml
+++ b/manifests/kiagnose.yaml
@@ -37,6 +37,7 @@ rules:
       - get
       - list
       - create
+      - delete
   - apiGroups: [ "rbac.authorization.k8s.io" ]
     resources:
       - roles

--- a/manifests/kiagnose.yaml
+++ b/manifests/kiagnose.yaml
@@ -23,6 +23,7 @@ rules:
       - create
       - update
       - patch
+      - delete
   - apiGroups: [ "" ]
     resources: [ "namespaces" ]
     verbs:


### PR DESCRIPTION
Currently, checkups are executed in ephemeral Namespace objects.

This change enables checkup execution in a target Namespace - the Namespace in which the user-supplied ConfigMap object is at.

Create and delete an ephemeral namespace only if the user-supplied ConfigMap object is at the "kiagnose" namespace.
Else, setup all objects in the target Namespace.

Signed-off-by: Orel Misan <omisan@redhat.com>

This PR implements the design document published in PR #126.

Followup PRs will:
1. Split checkup_test.go to test cases regarding ephemeral and target namespace scenarios.
2. Add failure test cases for the target namespace feature.


~~This PR depends on PR #140.~~