### PR TITLE
e2e: Remove redundant cd directives

### DIFF
--- a/automation/e2e.sh
+++ b/automation/e2e.sh
@@ -111,8 +111,6 @@ fi
 
 if [ -n "${OPT_RUN_TEST}" ]; then
     # kiagnose sanity e2e test uses the echo-checkup
-    cd checkups/echo
-
     echo "Post echo checkup ConfigMap & Job:"
     echo
 
@@ -167,8 +165,6 @@ EOF
     echo
     ${KUBECTL} delete job ${KIAGNOSE_JOB} -n ${KIAGNOSE_NAMESPACE}
     ${KUBECTL} delete configmap ${ECHO_CONFIGMAP} -n ${KIAGNOSE_NAMESPACE}
-
-    cd -
 fi
 
 if [ -n "${OPT_DELETE_CLUSTER}" ]; then


### PR DESCRIPTION
The echo checkup test case uses kubectl with yaml manifests received from stdin.
Because no files are being used from the checkup's directory - there is no need to change directories.

Signed-off-by: Orel Misan <omisan@redhat.com>