### PR TITLE
rbac: Fix name shadowing

### DIFF
--- a/kiagnose/internal/rbac/rbac.go
+++ b/kiagnose/internal/rbac/rbac.go
@@ -187,11 +187,11 @@ func waitForClusterRoleBindingDeletion(client kubernetes.Interface, name string,
 func CreateRoles(client kubernetes.Interface, roles []*rbacv1.Role) ([]*rbacv1.Role, error) {
 	var createdRoles []*rbacv1.Role
 	for _, role := range roles {
-		createRole, err := createRole(client, role)
+		createdRole, err := createRole(client, role)
 		if err != nil {
 			return nil, err
 		}
-		createdRoles = append(createdRoles, createRole)
+		createdRoles = append(createdRoles, createdRole)
 	}
 
 	return createdRoles, nil


### PR DESCRIPTION
Currenly, there is a variable name in CreateRoles() with the same name as createRole().

Rename `createRole` variable to `createdRole`.

Signed-off-by: Orel Misan <omisan@redhat.com>