### PR TITLE
checkup, tests: Fix wrong expected error

### DIFF
--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -195,7 +195,7 @@ func testTeardownShouldFailWhenNamespaceDeletionFails(t *testing.T) {
 
 	assert.NoError(t, testCheckup.Setup())
 
-	const expectedErr = "failed to delete ClusterRoleBinding"
+	const expectedErr = "failed to delete Namespace"
 	testClient.injectDeleteErrorForResource(namespaceResource, expectedErr)
 
 	assert.ErrorContains(t, testCheckup.Teardown(), expectedErr)


### PR DESCRIPTION
Currently, in a test checking failure to delete a namespace
object, we expect an error regarding ClusterRoleBinding.
Fix the expected error to refer to a namespace object.

Signed-off-by: Orel Misan <omisan@redhat.com>