### PR TITLE
CI: Fix echo checkup e2e tests to use locally built images

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -65,21 +65,3 @@ jobs:
           go-version: ${{ needs.go-versions.outputs.minimal }}
       - name: Run build
         run: ./automation/make.sh --build-core
-  e2e-test:
-    name: e2e
-    runs-on: ubuntu-latest
-    env:
-      KIND: /usr/local/bin/kind
-      KUBECTL: /usr/local/bin/kubectl
-      CRI: docker
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Build kiagnose image
-        run: ./automation/make.sh --build-core --build-core-image
-      - name: Deploy
-        run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster --deploy-kiagnose
-      - name: Run e2e tests
-        run: ./automation/make.sh --e2e -- --run-tests
-      - name: Delete cluster
-        run: ./automation/make.sh --e2e -- --delete-cluster

--- a/.github/workflows/checkup-echo.check.yaml
+++ b/.github/workflows/checkup-echo.check.yaml
@@ -34,6 +34,6 @@ jobs:
       - name: Deploy
         run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster --deploy-kiagnose
       - name: Run e2e tests
-        run: ./automation/make.sh --e2e -- --run-tests
+        run: ./checkups/echo/automation/make.sh --e2e -- --run-tests
       - name: Delete cluster
         run: ./automation/make.sh --e2e -- --delete-cluster

--- a/.github/workflows/checkup-echo.check.yaml
+++ b/.github/workflows/checkup-echo.check.yaml
@@ -9,10 +9,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-defaults:
-  run:
-    working-directory: ./checkups/echo
-
 jobs:
   unit-test:
     name: Unit Test
@@ -21,4 +17,23 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run unit tests
+        working-directory: ./checkups/echo
         run: ./automation/make.sh --unit-test
+  e2e-test:
+    name: e2e
+    runs-on: ubuntu-latest
+    env:
+      KIND: /usr/local/bin/kind
+      KUBECTL: /usr/local/bin/kubectl
+      CRI: docker
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Build kiagnose image
+        run: ./automation/make.sh --build-core --build-core-image
+      - name: Deploy
+        run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster --deploy-kiagnose
+      - name: Run e2e tests
+        run: ./automation/make.sh --e2e -- --run-tests
+      - name: Delete cluster
+        run: ./automation/make.sh --e2e -- --delete-cluster

--- a/.github/workflows/checkup-echo.check.yaml
+++ b/.github/workflows/checkup-echo.check.yaml
@@ -31,8 +31,15 @@ jobs:
         uses: actions/checkout@v2
       - name: Build kiagnose image
         run: ./automation/make.sh --build-core --build-core-image
-      - name: Deploy
-        run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster --deploy-kiagnose
+      - name: Build checkup image
+        working-directory: ./checkups/echo
+        run: ./automation/make.sh --build-checkup-image
+      - name: Start cluster
+        run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster
+      - name: Deploy kiagnose
+        run: ./automation/make.sh --e2e -- --deploy-kiagnose
+      - name: Deploy Echo checkup
+        run: ./checkups/echo/automation/make.sh --e2e -- --deploy-checkup
       - name: Run e2e tests
         run: ./checkups/echo/automation/make.sh --e2e -- --run-tests
       - name: Delete cluster

--- a/checkups/echo/automation/e2e.sh
+++ b/checkups/echo/automation/e2e.sh
@@ -28,8 +28,8 @@ KUBECTL=${KUBECTL:-$PWD/kubectl}
 KIND=${KIND:-$PWD/kind}
 CLUSTER_NAME=${CLUSTER_NAME:-kind}
 
-FRAMEWORK_IMAGE="quay.io/kiagnose/kiagnose:main"
-CHECKUP_IMAGE="quay.io/kiagnose/echo-checkup:main"
+FRAMEWORK_IMAGE="quay.io/kiagnose/kiagnose:devel"
+CHECKUP_IMAGE="quay.io/kiagnose/echo-checkup:devel"
 
 KIAGNOSE_NAMESPACE=kiagnose
 KIAGNOSE_JOB=echo-checkup

--- a/checkups/echo/automation/e2e.sh
+++ b/checkups/echo/automation/e2e.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+#
+
+set -e
+
+ARGCOUNT=$#
+
+SCRIPT_PATH=$(dirname $(realpath -s $0))
+
+KUBECTL=${KUBECTL:-$PWD/kubectl}
+
+KIND=${KIND:-$PWD/kind}
+CLUSTER_NAME=${CLUSTER_NAME:-kind}
+
+FRAMEWORK_IMAGE="quay.io/kiagnose/kiagnose:main"
+CHECKUP_IMAGE="quay.io/kiagnose/echo-checkup:main"
+
+KIAGNOSE_NAMESPACE=kiagnose
+KIAGNOSE_JOB=echo-checkup
+ECHO_CONFIGMAP=echo-checkup
+
+TARGET_NAMESPACE="echo-checkup-e2e-test"
+
+options=$(getopt --options "" \
+    --long deploy-checkup,run-tests,clean-run,help\
+    -- "${@}")
+eval set -- "$options"
+while true; do
+    case "$1" in
+    --deploy-checkup)
+        OPT_DEPLOY_CHECKUP=1
+        ;;
+    --run-tests)
+        OPT_RUN_TEST=1
+        ;;
+    --clean-run)
+        OPT_CLEAN_RUN=1
+        ;;
+    --help)
+        set +x
+        echo -n "$0 [--deploy-checkup] [--run-tests] [--clean-run]"
+        exit
+        ;;
+    --)
+        shift
+        break
+        ;;
+    esac
+    shift
+done
+
+if [ "${ARGCOUNT}" -eq "0" ] ; then
+    OPT_DEPLOY_CHECKUP=1
+    OPT_RUN_TEST=1
+fi
+
+if [ -n "${OPT_DEPLOY_CHECKUP}" ]; then
+    echo
+    echo "Deploy echo checkup..."
+    echo
+
+    ${KIND} load docker-image "${CHECKUP_IMAGE}" --name "${CLUSTER_NAME}"
+fi
+
+if [ -n "${OPT_RUN_TEST}" ]; then
+    ${KUBECTL} create namespace ${TARGET_NAMESPACE}
+    echo
+    echo "Deploy ConfigMap with input data: "
+    echo
+    cat <<EOF | ${KUBECTL} apply -f -
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${ECHO_CONFIGMAP}
+  namespace: ${TARGET_NAMESPACE}
+data:
+  spec.image: ${CHECKUP_IMAGE}
+  spec.timeout: 1m
+  spec.param.message: "Hi!"
+EOF
+
+    echo
+    echo "Deploy and run kiagnose job: "
+    echo
+    cat <<EOF | ${KUBECTL} apply -f -
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${KIAGNOSE_JOB}
+  namespace: ${KIAGNOSE_NAMESPACE}
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccount: kiagnose
+      restartPolicy: Never
+      containers:
+        - name: framework
+          image: ${FRAMEWORK_IMAGE}
+          env:
+            - name: CONFIGMAP_NAMESPACE
+              value: ${TARGET_NAMESPACE}
+            - name: CONFIGMAP_NAME
+              value: ${ECHO_CONFIGMAP}
+EOF
+
+    ${KUBECTL} wait --for=condition=complete --timeout=10m job.batch/${KIAGNOSE_JOB} -n ${KIAGNOSE_NAMESPACE}
+
+     echo
+     echo "Result:"
+     echo
+     ${KUBECTL} get configmap ${ECHO_CONFIGMAP} -n ${TARGET_NAMESPACE} -o yaml
+     ${KUBECTL} get configmap ${ECHO_CONFIGMAP} -n ${TARGET_NAMESPACE} -o yaml | grep -q "status.result.echo: Hi!"
+fi
+
+if [ -n "${OPT_CLEAN_RUN}" ];then
+  ${KUBECTL} delete job ${KIAGNOSE_JOB} -n ${KIAGNOSE_NAMESPACE} --ignore-not-found
+  ${KUBECTL} delete configmap ${ECHO_CONFIGMAP} -n ${TARGET_NAMESPACE} --ignore-not-found
+fi

--- a/checkups/echo/automation/make.sh
+++ b/checkups/echo/automation/make.sh
@@ -21,6 +21,8 @@ set -e
 
 ARGCOUNT=$#
 
+SCRIPT_PATH=$(dirname $(realpath -s $0))
+
 CRI=${CRI:-podman}
 
 IMAGE_REGISTRY=${IMAGE_REGISTRY:-quay.io}
@@ -31,7 +33,7 @@ ECHO_IMAGE_TAG=${ECHO_IMAGE_TAG:-devel}
 ECHO_IMAGE="${IMAGE_REGISTRY}/${IMAGE_ORG}/${ECHO_IMAGE_NAME}:${ECHO_IMAGE_TAG}"
 
 options=$(getopt --options "" \
-    --long unit-test,build-checkup-image,push-checkup-image,help\
+    --long unit-test,build-checkup-image,push-checkup-image,e2e,help\
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -45,9 +47,12 @@ while true; do
     --push-checkup-image)
         OPT_PUSH_IMAGE=1
         ;;
+    --e2e)
+        OPT_E2E=1
+        ;;
     --help)
         set +x
-        echo "$0 [--unit-test] [--build-checkup-image] [--push-checkup-image]"
+        echo "$0 [--unit-test] [--e2e] [--build-checkup-image] [--push-checkup-image]"
         exit
         ;;
     --)
@@ -75,4 +80,8 @@ fi
 if [ -n "${OPT_PUSH_IMAGE}" ]; then
    echo "Pushing \"${ECHO_IMAGE}\"..."
    ${CRI} push ${ECHO_IMAGE}
+fi
+
+if [ -n "${OPT_E2E}" ]; then
+    ${SCRIPT_PATH}/e2e.sh $@
 fi


### PR DESCRIPTION
Currently, Kiagnose e2e test is a success scenario with the echo checkup.
Move this e2e test to be under the "echo.checks" workflow in order to be aligned with the VM latency checkup workflow.

Furthermore, the echo e2e test is using kiagnose and echo-checkup images pulled from quay and not locally built images
from current source code.

Move the echo e2e test code from `automation/e2e.sh` to `checkups/echo/automation/e2e.sh`.
Use locally built images of kiagnose and echo-checkup.
Align the e2e job with the e2e job of vm latency checkup.
Use target namespace instead of ephemeral namespace in the e2e test.

Signed-off-by: Orel Misan <omisan@redhat.com>