### PR TITLE
e2e infra: Support multi nodes cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ bin/
 # Others
 kind
 kubectl
+# koko - containers network connector untility
+koko

--- a/automation/e2e.sh
+++ b/automation/e2e.sh
@@ -28,10 +28,15 @@ KIND_VERSION=${KIND_VERSION:-v0.12.0}
 KIND=${KIND:-$PWD/kind}
 CLUSTER_NAME=${CLUSTER_NAME:-kind}
 
+KOKO_VERSION=${KOKO_VERSION:-0.83}
+KOKO=${KOKO:-$PWD/koko}
+BRIDGE_NAME=${BRIDGE_NAME:-br10}
+VETH_NAME=${VETH_NAME:-link_${BRIDGE_NAME}}
+
 FRAMEWORK_IMAGE="quay.io/kiagnose/kiagnose:devel"
 
 options=$(getopt --options "" \
-    --long install-kind,install-kubectl,create-cluster,delete-cluster,deploy-kiagnose,help\
+    --long install-kind,install-kubectl,create-cluster,create-multi-node-cluster,delete-cluster,deploy-kiagnose,help\
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -45,6 +50,9 @@ while true; do
     --create-cluster)
         OPT_CREATE_CLUSTER=1
         ;;
+    --create-multi-node-cluster)
+        OPT_CREATE_MULTI_NODE_CLUSTER=1
+        ;;
     --delete-cluster)
         OPT_DELETE_CLUSTER=1
         ;;
@@ -53,7 +61,7 @@ while true; do
         ;;
     --help)
         set +x
-        echo "$0 [--install-kind] [--install-kubectl] [--create-cluster] [--delete-cluster] [--deploy-kiagnose]"
+        echo "$0 [--install-kind] [--install-kubectl] [--create-cluster] [--create-multi-node-cluster] [--delete-cluster] [--deploy-kiagnose]"
         exit
         ;;
     --)
@@ -98,6 +106,45 @@ if [ -n "${OPT_CREATE_CLUSTER}" ]; then
     else
         echo "Cluster '${CLUSTER_NAME}' already exists!"
     fi
+fi
+
+if [ -n "${OPT_CREATE_MULTI_NODE_CLUSTER}" ]; then
+    if ! ${KIND} get clusters | grep "${CLUSTER_NAME}"; then
+        cat <<EOF | ${KIND} create cluster --wait 2m --config -
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+EOF
+        echo "Waiting for the network to be ready..."
+        ${KUBECTL} wait --for=condition=ready pods --namespace=kube-system -l k8s-app=kube-dns --timeout=2m
+        echo "K8S cluster is up:"
+        ${KUBECTL} get nodes -o wide
+    else
+        echo "Cluster '${CLUSTER_NAME}' already exists!"
+    fi
+
+    if [ ! -f "${KOKO}" ]; then
+        curl -Lo "${KOKO}" https://github.com/redhat-nfvpe/koko/releases/download/v${KOKO_VERSION}/koko_${KOKO_VERSION}_linux_amd64
+        chmod +x "${KOKO}"
+        echo "koko installed successfully at ${KOKO}"
+    fi
+
+    echo "Interconnect worker nodes with veth pair, requires root privileges"
+    worker1="kind-worker"
+    worker2="kind-worker2"
+    worker1_pid=$(${CRI} inspect --format "{{ .State.Pid }}" "${worker1}")
+    worker2_pid=$(${CRI} inspect --format "{{ .State.Pid }}" "${worker2}")
+    sudo ${KOKO} -p "${worker1_pid},${VETH_NAME}" -p "${worker2_pid},${VETH_NAME}"
+
+    echo "Establish connectivity between worker nodes over bridge network"
+    for node in "${worker1}" "${worker2}"; do
+      ${CRI} exec ${node} ip link add ${BRIDGE_NAME} type bridge
+      ${CRI} exec ${node} ip link set ${VETH_NAME} master ${BRIDGE_NAME}
+      ${CRI} exec ${node} ip link set up ${BRIDGE_NAME}
+    done
 fi
 
 if [ -n "${OPT_DEPLOY_KIAGNOSE}" ]; then

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -32,6 +32,8 @@ KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-v0.53.0}
 KUBEVIRT_USE_EMULATION=${KUBEVIRT_USE_EMULATION:-"false"}
 CNAO_VERSION=${CNAO_VERSION:-v0.74.0}
 
+BRIDGE_NAME=${BRIDGE_NAME:-br10}
+
 FRAMEWORK_IMAGE="quay.io/kiagnose/kiagnose:devel"
 CHECKUP_IMAGE="quay.io/kiagnose/kubevirt-vm-latency:devel"
 
@@ -149,11 +151,11 @@ spec:
   config: |
     {
       "cniVersion":"0.3.1",
-      "name": "br10",
+      "name": "${BRIDGE_NAME}",
       "plugins": [
           {
               "type": "cnv-bridge",
-              "bridge": "br10"
+              "bridge": "${BRIDGE_NAME}"
           }
       ]
     }


### PR DESCRIPTION
This change is required to support testing network connectivity
across cluster nodes over linux-bridge.

Currently KinD does not support secondary networks for cluster nodes.

Each worker node is connected through veth pair to establish connectivity.
Next each node veth is connected to its own bridge that the cluster workloads will consume through NetworkAttachmentDefinition.

Notes:
- This change introduces using koko [[1]](https://github.com/redhat-nfvpe/koko) utility, it enables connecting between containers network namespaces in a convenient way.
- Connecting between container network namespaces requires high privileges.
- There is an emerging project that enables spinning up KinD cluster with secondary networks [[2]](https://github.com/aojea/kind-networking-plugins/tree/main/baremetal)
It seems to be in PoC stage, once it will productive we can use it.

[1] https://github.com/redhat-nfvpe/koko
[2] https://github.com/aojea/kind-networking-plugins/tree/main/baremetal

Signed-off-by: Or Mergi <ormergi@redhat.com>