### PR TITLE
kubevirt-vm-latency: Ensure VMs are not scheduled on the same node by defualt 

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
@@ -104,9 +104,6 @@ func TestCheckupTeardownShouldFailWhen(t *testing.T) {
 		defer cancel()
 
 		assert.NoError(t, testCheckup.Preflight())
-
-		testClient.returnVmi = newTestReadyVmi()
-
 		assert.NoError(t, testCheckup.Setup(testCtx))
 
 		expectedErr := errors.New("delete vmi test error")
@@ -125,9 +122,6 @@ func TestCheckupTeardownShouldFailWhen(t *testing.T) {
 		)
 
 		assert.NoError(t, testCheckup.Preflight())
-
-		testClient.returnVmi = newTestReadyVmi()
-
 		assert.NoError(t, testCheckup.Setup(context.Background()))
 
 		testCtx, cancel := context.WithTimeout(context.Background(), testTimeout)
@@ -164,7 +158,6 @@ func TestCheckupSetupShouldCreateVMsWith(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			testClient := &clientStub{
 				returnNetAttachDef: testCase.netAttachDef,
-				returnVmi:          newTestReadyVmi(),
 			}
 			testCheckup := checkup.New(
 				testClient,
@@ -182,17 +175,6 @@ func TestCheckupSetupShouldCreateVMsWith(t *testing.T) {
 			}
 		})
 	}
-}
-
-func newTestReadyVmi() *kvcorev1.VirtualMachineInstance {
-	return &kvcorev1.VirtualMachineInstance{Status: kvcorev1.VirtualMachineInstanceStatus{
-		Conditions: []kvcorev1.VirtualMachineInstanceCondition{
-			{
-				Type:   kvcorev1.VirtualMachineInstanceAgentConnected,
-				Status: k8scorev1.ConditionTrue,
-			},
-		},
-	}}
 }
 
 func newTestNetAttachDef(cniPluginName string) *netattdefv1.NetworkAttachmentDefinition {
@@ -215,8 +197,9 @@ func newTestsCheckupParameters() config.CheckupParameters {
 }
 
 type clientStub struct {
-	returnVmi          *kvcorev1.VirtualMachineInstance
-	createdVmis        []*kvcorev1.VirtualMachineInstance
+	createdVmis    map[string]*kvcorev1.VirtualMachineInstance
+	vmiNodeNameMap map[string]string
+
 	returnNetAttachDef *netattdefv1.NetworkAttachmentDefinition
 
 	failGetNetAttachDef error
@@ -225,13 +208,30 @@ type clientStub struct {
 	failDeleteVmi       error
 }
 
-func (c *clientStub) GetVirtualMachineInstance(_, _ string) (*kvcorev1.VirtualMachineInstance, error) {
-	return c.returnVmi, c.failGetVmi
+func (c *clientStub) GetVirtualMachineInstance(_, name string) (*kvcorev1.VirtualMachineInstance, error) {
+	return c.createdVmis[name], c.failGetVmi
 }
 
 func (c *clientStub) CreateVirtualMachineInstance(_ string, v *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error) {
-	c.createdVmis = append(c.createdVmis, v)
-	return v, c.failCreateVmi
+	if c.failCreateVmi != nil {
+		return nil, c.failCreateVmi
+	}
+
+	if c.createdVmis == nil {
+		c.createdVmis = map[string]*kvcorev1.VirtualMachineInstance{}
+	}
+	c.createdVmis[v.Name] = v
+
+	v.Status.Conditions = append(v.Status.Conditions, kvcorev1.VirtualMachineInstanceCondition{
+		Type:   kvcorev1.VirtualMachineInstanceAgentConnected,
+		Status: k8scorev1.ConditionTrue,
+	})
+
+	if nodeName, ok := c.vmiNodeNameMap[v.Name]; ok {
+		v.Status.NodeName = nodeName
+	}
+
+	return v, nil
 }
 
 func (c *clientStub) DeleteVirtualMachineInstance(_, _ string) error {

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
@@ -24,7 +24,6 @@ import (
 	k8scorev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	kvcorev1 "kubevirt.io/api/core/v1"
 )
 
@@ -153,6 +152,29 @@ func newContainerDiskVolume(name, image string) kvcorev1.Volume {
 				Image: image,
 			},
 		},
+	}
+}
+
+// WithNodeAffinity adds node affinity rule of match-expression kind with the given requirement.
+func WithNodeAffinity(nodeSelectorRequirement *k8scorev1.NodeSelectorRequirement) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if nodeSelectorRequirement == nil {
+			return
+		}
+
+		term := []k8scorev1.NodeSelectorTerm{
+			{
+				MatchExpressions: []k8scorev1.NodeSelectorRequirement{*nodeSelectorRequirement},
+			},
+		}
+		affinityRule := &k8scorev1.Affinity{
+			NodeAffinity: &k8scorev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &k8scorev1.NodeSelector{
+					NodeSelectorTerms: term,
+				},
+			},
+		}
+		vmi.Spec.Affinity = affinityRule
 	}
 }
 


### PR DESCRIPTION
Currently, the source and target node may end up scheduled on
the same node.
Though this may be useful for some use cases it's not the desired default behavior.

With these changes the checkup setup is changed as follows:
1. Create source VM.
2. Wait for the source VM to be ready.
3. Look into the source VM status and create the target VM  with the corresponding node anti-affinity rule.
4. Wait for the target VM to be ready.

The source and target will not be scheduled on the same node.

In order to force the VMs to be scheduled on the same node, the user should specify both source and target node names in
the checkup config.
