### PR TITLE
kubevirt-vm-latency: Ensure VMs are not scheduled on the same node by default

### DIFF
--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -88,7 +88,7 @@ jobs:
         working-directory: ./checkups/kubevirt-vm-latency
         run: ./automation/make.sh --build-checkup --build-checkup-image
       - name: Start cluster
-        run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster
+        run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-multi-node-cluster
       - name: Deploy kiagnose
         run: ./automation/make.sh --e2e -- --deploy-kiagnose
       - name: Deploy kubevirt, CNAO and the NetworkAttachementDefinition

--- a/checkups/kubevirt-vm-latency/README.md
+++ b/checkups/kubevirt-vm-latency/README.md
@@ -81,10 +81,14 @@ The checkup is configured by the following parameters:
 | `network_attachment_definition_namespace`<br/>`network_attachment_definition_name` | `NetworkAttachmentDefinition` object on which <br/> the VMs are connected to and measure network latency.                    |
 | `sample_duration_seconds`                                                          | Network latency measurement sample time (optional).<br/> Default is 5 seconds.                                               |
 | `max_desired_latency_milliseconds`                                                 | Maximal network latency accepted, if the actual latency <br/> is higher the checkup will be considered as failed (optional). |
-| `source_node`<br/>`target_node`                                                    | Two ends in the of the network latency measurement (optional).                                                               |
+| `source_node`<br/>`target_node`                                                    | Two ends of the network latency measurement (optional).<br/> When used, specifying both is mandatory.                        |
 
 > **_Note_**:
 > `timeout` should be greater than `sample_duration_seconds`.
+
+> **_Note_**:
+> By default the checkup source and target VMs will be created in a way they won't end up on the same cluster node.</br>
+> Specifying both `source_node` and `target_node` will override this behaviour and each VM will be created on the desired node.
 
 ### Example
 ```yaml

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
@@ -62,6 +62,10 @@ var (
 	ErrInvalidNetworkName               = fmt.Errorf("%q environment variable is invalid", NetworkNameEnvVarName)
 	ErrNetworkNamespaceMissing          = fmt.Errorf("%q environment variable is missing", NetworkNamespaceEnvVarName)
 	ErrInvalidNetworkNamespace          = fmt.Errorf("%q environment variable is invalid", NetworkNamespaceEnvVarName)
+	ErrSourceNodeNameMissing            = fmt.Errorf("%q environment variable is missing", SourceNodeNameEnvVarName)
+	ErrInvalidSourceNodeName            = fmt.Errorf("%q environment variable is invalid", SourceNodeNameEnvVarName)
+	ErrTargetNodeNameMissing            = fmt.Errorf("%q environment variable is missing", TargetNodeNameEnvVarName)
+	ErrInvalidTargetNodeName            = fmt.Errorf("%q environment variable is invalid", TargetNodeNameEnvVarName)
 )
 
 const (
@@ -121,6 +125,10 @@ func New(env map[string]string) (Config, error) {
 		}
 	}
 
+	if err := validateNodeNames(env); err != nil {
+		return Config{}, err
+	}
+
 	return Config{
 		ResultsConfigMapName:      resultsConfigMapName,
 		ResultsConfigMapNamespace: resultsConfigMapNamespace,
@@ -133,4 +141,25 @@ func New(env map[string]string) (Config, error) {
 			DesiredMaxLatencyMilliseconds:        desiredMaxLatency,
 		},
 	}, nil
+}
+
+func validateNodeNames(env map[string]string) error {
+	sourceNodeName, sourceNodeNameExists := env[SourceNodeNameEnvVarName]
+	targetNodeName, targetNodeNameExists := env[TargetNodeNameEnvVarName]
+
+	switch {
+	case !sourceNodeNameExists && targetNodeNameExists:
+		return ErrSourceNodeNameMissing
+	case !targetNodeNameExists && sourceNodeNameExists:
+		return ErrTargetNodeNameMissing
+	case sourceNodeNameExists && targetNodeNameExists:
+		if sourceNodeName == "" {
+			return ErrInvalidSourceNodeName
+		}
+		if targetNodeName == "" {
+			return ErrInvalidTargetNodeName
+		}
+	}
+
+	return nil
 }

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/affinity.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/affinity.go
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package vmi
+
+import (
+	k8scorev1 "k8s.io/api/core/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kvcorev1 "kubevirt.io/api/core/v1"
+)
+
+// WithAffinity adds the given affinity.
+func WithAffinity(affinity *k8scorev1.Affinity) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if affinity != nil {
+			vmi.Spec.Affinity = affinity
+		}
+	}
+}
+
+// NewNodeAffinity returns new node affinity with node selector of the given node name.
+// Adding it to a VMI will make sure it will schedule on the given node name.
+func NewNodeAffinity(nodeName string) *k8scorev1.NodeAffinity {
+	req := k8scorev1.NodeSelectorRequirement{
+		Key:      k8scorev1.LabelHostname,
+		Operator: k8scorev1.NodeSelectorOpIn,
+		Values:   []string{nodeName},
+	}
+	term := []k8scorev1.NodeSelectorTerm{
+		{
+			MatchExpressions: []k8scorev1.NodeSelectorRequirement{req},
+		},
+	}
+	return &k8scorev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &k8scorev1.NodeSelector{
+			NodeSelectorTerms: term,
+		},
+	}
+}
+
+// NewPodAntiAffinity returns new pod anti-affinity with label selector of the given label key and value.
+// Adding it to a VMI will make sure it won't schedule on the same node as other VMIs with the given label.
+func NewPodAntiAffinity(label Label) *k8scorev1.PodAntiAffinity {
+	req := k8smetav1.LabelSelectorRequirement{
+		Operator: k8smetav1.LabelSelectorOpIn,
+		Key:      label.Key,
+		Values:   []string{label.Value},
+	}
+	labelSelector := &k8smetav1.LabelSelector{
+		MatchExpressions: []k8smetav1.LabelSelectorRequirement{req},
+	}
+	term := k8scorev1.PodAffinityTerm{
+		TopologyKey:   k8scorev1.LabelHostname,
+		LabelSelector: labelSelector,
+	}
+	return &k8scorev1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []k8scorev1.PodAffinityTerm{term},
+	}
+}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
@@ -59,16 +59,20 @@ func withTerminationGracePeriodSecond(duration int64) Option {
 	}
 }
 
-// WithNodeSelector ensures that the VMI gets scheduled on the specified node.
-func WithNodeSelector(nodeName string) Option {
+type Label struct {
+	Key, Value string
+}
+
+// WithLabels adds the given labels.
+func WithLabels(labels ...Label) Option {
 	return func(vmi *kvcorev1.VirtualMachineInstance) {
-		if nodeName == "" {
-			return
+		if vmi.ObjectMeta.Labels == nil {
+			vmi.ObjectMeta.Labels = map[string]string{}
 		}
-		if vmi.Spec.NodeSelector == nil {
-			vmi.Spec.NodeSelector = map[string]string{}
+
+		for _, label := range labels {
+			vmi.ObjectMeta.Labels[label.Key] = label.Value
 		}
-		vmi.Spec.NodeSelector[k8scorev1.LabelHostname] = nodeName
 	}
 }
 


### PR DESCRIPTION
Currently, when both the source and the target node are not defined by the user, the source and target VMs may end up scheduled on the same node.
Though this may be useful for some use cases it's not the desired default behavior.

With this PR changes, VMs will create with `latency-check-vm` label which indicates they belong to the latency checkup.
As long as both "source_node" and "target_node" are not specified in the checkup config, both VMs won't end up running on the same node (using a [Pod Anti Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#types-of-inter-pod-affinity-and-anti-affinity) rule and the `latency-check-vm` label as the `labelSelector`).

In order to override this behavior and force both VMs to run on the same node, specify both `source_node` and `target_node` in the checkup config (each VM will be created with a corresponding [Node Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) rule).

Specifying only one of `source_node` and `source_node` is no longer supported.

~~This PR depends on #152 (first commit), it enables e2e testing of this PR changes.~~