### PR TITLE
vm latency, client: Fix UpdateConfigMap()

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
@@ -64,7 +64,7 @@ func (c *Client) UpdateConfigMap(namespace, name string, data map[string]string)
 	}
 	cm.Data = data
 
-	if _, err := c.KubevirtClient.CoreV1().ConfigMaps(namespace).Update(context.Background(), cm, metav1.UpdateOptions{}); err != nil {
+	if _, err = c.KubevirtClient.CoreV1().ConfigMaps(namespace).Update(context.Background(), cm, metav1.UpdateOptions{}); err != nil {
 		return err
 	}
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
@@ -57,12 +57,12 @@ func New() (*Client, error) {
 	return &Client{c, cniClient}, nil
 }
 
-func (c *Client) UpdateConfigMap(namespace, name string, date map[string]string) error {
+func (c *Client) UpdateConfigMap(namespace, name string, data map[string]string) error {
 	cm, err := c.KubevirtClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
-	cm.Data = date
+	cm.Data = data
 
 	if _, err := c.KubevirtClient.CoreV1().ConfigMaps(namespace).Update(context.Background(), cm, metav1.UpdateOptions{}); err != nil {
 		return err


### PR DESCRIPTION
Perform two small fixes on `client.UpdateConfigMap()`:
1. Fix a typo in parameter name: `date` -> `data`.
2. Fix a variable shadowing.