### PR TITLE
vm latency, reporter: Export Reporter struct

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/reporter/reporter.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/reporter/reporter.go
@@ -32,21 +32,21 @@ type configMapUpdater interface {
 	UpdateConfigMap(string, string, map[string]string) error
 }
 
-type reporter struct {
+type Reporter struct {
 	client             configMapUpdater
 	configMapName      string
 	configMapNamespace string
 }
 
-func New(c configMapUpdater, configMapNamespace, configMapName string) *reporter {
-	return &reporter{
+func New(c configMapUpdater, configMapNamespace, configMapName string) *Reporter {
+	return &Reporter{
 		client:             c,
 		configMapNamespace: configMapNamespace,
 		configMapName:      configMapName,
 	}
 }
 
-func (r *reporter) Report(s status.Status) error {
+func (r *Reporter) Report(s status.Status) error {
 	data := formatStatus(s)
 
 	if raw, err := json.MarshalIndent(data, "", " "); err == nil {


### PR DESCRIPTION
Currently, the `reporter.reporter` struct is not exported, but is returned from `reporter.New()`.

Export `reporter.Reporter` struct, in order for it to be handled more conveniently (for example in tests).

Signed-off-by: Orel Misan <omisan@redhat.com>