### PR TITLE
automation, e2e: Print kind and kubectl versions

### DIFF
--- a/automation/e2e.sh
+++ b/automation/e2e.sh
@@ -85,6 +85,7 @@ if [ -n "${OPT_INSTALL_KIND}" ]; then
         curl -Lo "${KIND}" https://kind.sigs.k8s.io/dl/"${KIND_VERSION}"/kind-linux-amd64
         chmod +x "${KIND}"
         echo "kind installed successfully at ${KIND}"
+        ${KIND} version
     fi
 fi
 

--- a/automation/e2e.sh
+++ b/automation/e2e.sh
@@ -94,6 +94,7 @@ if [ -n "${OPT_INSTALL_KUBECTL}" ]; then
         curl -Lo "${KUBECTL}" https://dl.k8s.io/release/"${KUBECTL_VERSION}"/bin/linux/amd64/kubectl
         chmod +x "${KUBECTL}"
         echo "kubectl installed successfully at ${KUBECTL}"
+        ${KUBECTL} version --client
     fi
 fi
 


### PR DESCRIPTION
Print the versions of `kind` and `kubectl` after installing them.
