### PR TITLE
github actions, vm latency e2e: Use custom kind and kubectl versions

### DIFF
--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -75,7 +75,6 @@ jobs:
     name: e2e
     runs-on: ubuntu-latest
     env:
-      KUBECTL: /usr/local/bin/kubectl
       CRI: docker
       KUBEVIRT_USE_EMULATION: true
     steps:

--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -75,7 +75,6 @@ jobs:
     name: e2e
     runs-on: ubuntu-latest
     env:
-      KIND: /usr/local/bin/kind
       KUBECTL: /usr/local/bin/kubectl
       CRI: docker
       KUBEVIRT_USE_EMULATION: true


### PR DESCRIPTION
Currently, the VM latency checkup's e2e tests are using `kind` and `kubectl` supplied by the runner-image [1].

Use the `kind` and `kubectl` versions stated at `automation/e2e.sh`.

[1] https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#tools
