### PR TITLE
github actions, echo e2e: Use custom kind and kubectl versions

### DIFF
--- a/.github/workflows/checkup-echo.check.yaml
+++ b/.github/workflows/checkup-echo.check.yaml
@@ -23,7 +23,6 @@ jobs:
     name: e2e
     runs-on: ubuntu-latest
     env:
-      KUBECTL: /usr/local/bin/kubectl
       CRI: docker
     steps:
       - name: Check out code

--- a/.github/workflows/checkup-echo.check.yaml
+++ b/.github/workflows/checkup-echo.check.yaml
@@ -23,7 +23,6 @@ jobs:
     name: e2e
     runs-on: ubuntu-latest
     env:
-      KIND: /usr/local/bin/kind
       KUBECTL: /usr/local/bin/kubectl
       CRI: docker
     steps:


### PR DESCRIPTION
This is a follow-up to PR #162.

Currently, the echo checkup's e2e tests are using `kind` and `kubectl` supplied by the runner-image [1].
Use the `kind` and `kubectl` versions stated at automation/e2e.sh.

[1] https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#tools