### PR TITLE
kubevirt-vm-latnecy: Randomize VMs affinity label

### DIFF
--- a/checkups/kubevirt-vm-latency/go.sum
+++ b/checkups/kubevirt-vm-latency/go.sum
@@ -143,7 +143,6 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/containernetworking/cni v0.7.1 h1:fE3r16wpSEyaqY4Z4oFrLMmIGfBYIKpPrHK31EJ9FzE=
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v1.1.1 h1:ky20T7c0MvKvbMOwS/FrlbNwjEoqJEUUYfsL4b0mc4k=
 github.com/containernetworking/cni v1.1.1/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=

--- a/checkups/kubevirt-vm-latency/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/checkups/kubevirt-vm-latency/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/checkups/kubevirt-vm-latency/vendor/modules.txt
+++ b/checkups/kubevirt-vm-latency/vendor/modules.txt
@@ -303,6 +303,7 @@ k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/util/managedfields
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/validation

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -49,6 +49,7 @@ func TestLauncherShouldFail(t *testing.T) {
 		k8scorev1.NamespaceDefault,
 		config.CheckupParameters{},
 		&checkerStub{checkFailure: errorCheck},
+		&uidGeneratorStub{},
 	)
 	testLauncher := launcher.New(testCheckup, reporterStub{})
 
@@ -62,6 +63,7 @@ func TestLauncherShouldRunSuccessfully(t *testing.T) {
 		k8scorev1.NamespaceDefault,
 		config.CheckupParameters{},
 		&checkerStub{},
+		&uidGeneratorStub{},
 	)
 	testLauncher := launcher.New(testCheckup, reporterStub{})
 
@@ -165,6 +167,7 @@ func TestLauncherShouldSuccessfullyProduceStatusResults(t *testing.T) {
 			TargetNodeName: targetNodeName,
 		},
 		&checkerStub{},
+		&uidGeneratorStub{},
 	)
 	testLauncher := launcher.New(testCheckup, testReporter)
 
@@ -313,4 +316,10 @@ func (c *checkerStub) CheckDuration() time.Duration {
 
 func (c *fakeClient) UpdateConfigMap(_, _ string, _ map[string]string) error {
 	return nil
+}
+
+type uidGeneratorStub struct{}
+
+func (u *uidGeneratorStub) UID() string {
+	return ""
 }

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/uidgenerator/uidgenerator.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/uidgenerator/uidgenerator.go
@@ -1,0 +1,14 @@
+package uidgenerator
+
+import k8srand "k8s.io/apimachinery/pkg/util/rand"
+
+func New() uidGenerator {
+	return uidGenerator{}
+}
+
+type uidGenerator struct{}
+
+func (u uidGenerator) UID() string {
+	const uidLength = 8
+	return k8srand.String(uidLength)
+}

--- a/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/latency"
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/launcher"
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/reporter"
+	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/uidgenerator"
 )
 
 func Run(env map[string]string, namespace string) error {
@@ -40,7 +41,7 @@ func Run(env map[string]string, namespace string) error {
 	}
 
 	l := launcher.New(
-		checkup.New(c, namespace, cfg.CheckupParameters, latency.New(c)),
+		checkup.New(c, namespace, cfg.CheckupParameters, latency.New(c), uidgenerator.New()),
 		reporter.New(c, cfg.ResultsConfigMapNamespace, cfg.ResultsConfigMapName),
 	)
 	return l.Run()


### PR DESCRIPTION
Following #155, https://github.com/kiagnose/kiagnose/pull/155#discussion_r969254470

Running more than one instance of kubevirt latency checkup is not possible due to the fact that VMs of the first instance will cause the VMs of the other instances to be stuck on the scheduling phase due to the first instance VMs affinity rules.

Change the VMs label that is used by their Pod anti-affinity to have a random value, so that VMs that were created by one instance of the checkup won't block other instances VMs.

Rebased on #155, only the last commit is relevant.