### PR TITLE
vmlatency, launcher, tests: Fix a call to assert.Equal()

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -174,7 +174,7 @@ func TestLauncherShouldSuccessfullyProduceStatusResults(t *testing.T) {
 		SourceNode: sourceNodeName,
 		TargetNode: targetNodeName,
 	}
-	assert.Equal(t, testCheckup.Results(), expectedResults)
+	assert.Equal(t, expectedResults, testCheckup.Results())
 }
 
 var (


### PR DESCRIPTION
assert.Equal() expects the expected results to be the first argument, and the actual argument second.

Fix a call which was in the reverse order.

Signed-off-by: Orel Misan <omisan@redhat.com>