### PR TITLE
vmlatency, config: Refactor

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
@@ -54,13 +54,9 @@ type Config struct {
 
 var (
 	ErrInvalidEnv                       = errors.New("environment is invalid")
-	ErrResultsConfigMapNameMissing      = fmt.Errorf("%q environment variable is missing", ResultsConfigMapNameEnvVarName)
 	ErrInvalidResultsConfigMapName      = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNameEnvVarName)
-	ErrResultsConfigMapNamespaceMissing = fmt.Errorf("%q environment variable is missing", ResultsConfigMapNamespaceEnvVarName)
 	ErrInvalidResultsConfigMapNamespace = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNamespaceEnvVarName)
-	ErrNetworkNameMissing               = fmt.Errorf("%q environment variable is missing", NetworkNameEnvVarName)
 	ErrInvalidNetworkName               = fmt.Errorf("%q environment variable is invalid", NetworkNameEnvVarName)
-	ErrNetworkNamespaceMissing          = fmt.Errorf("%q environment variable is missing", NetworkNamespaceEnvVarName)
 	ErrInvalidNetworkNamespace          = fmt.Errorf("%q environment variable is invalid", NetworkNamespaceEnvVarName)
 	ErrSourceNodeNameMissing            = fmt.Errorf("%q environment variable is missing", SourceNodeNameEnvVarName)
 	ErrInvalidSourceNodeName            = fmt.Errorf("%q environment variable is invalid", SourceNodeNameEnvVarName)
@@ -78,34 +74,22 @@ func New(env map[string]string) (Config, error) {
 		return Config{}, ErrInvalidEnv
 	}
 
-	resultsConfigMapName, exists := env[ResultsConfigMapNameEnvVarName]
-	if !exists {
-		return Config{}, ErrResultsConfigMapNameMissing
-	}
+	resultsConfigMapName := env[ResultsConfigMapNameEnvVarName]
 	if resultsConfigMapName == "" {
 		return Config{}, ErrInvalidResultsConfigMapName
 	}
 
-	resultsConfigMapNamespace, exists := env[ResultsConfigMapNamespaceEnvVarName]
-	if !exists {
-		return Config{}, ErrResultsConfigMapNamespaceMissing
-	}
+	resultsConfigMapNamespace := env[ResultsConfigMapNamespaceEnvVarName]
 	if resultsConfigMapNamespace == "" {
 		return Config{}, ErrInvalidResultsConfigMapNamespace
 	}
 
-	networkName, exists := env[NetworkNameEnvVarName]
-	if !exists {
-		return Config{}, ErrNetworkNameMissing
-	}
+	networkName := env[NetworkNameEnvVarName]
 	if networkName == "" {
 		return Config{}, ErrInvalidNetworkName
 	}
 
-	networkNamespace, exists := env[NetworkNamespaceEnvVarName]
-	if !exists {
-		return Config{}, ErrNetworkNamespaceMissing
-	}
+	networkNamespace := env[NetworkNamespaceEnvVarName]
 	if networkNamespace == "" {
 		return Config{}, ErrInvalidNetworkNamespace
 	}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
@@ -53,15 +53,12 @@ type Config struct {
 }
 
 var (
-	ErrInvalidEnv                       = errors.New("environment is invalid")
-	ErrInvalidResultsConfigMapName      = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNameEnvVarName)
-	ErrInvalidResultsConfigMapNamespace = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNamespaceEnvVarName)
-	ErrInvalidNetworkName               = fmt.Errorf("%q environment variable is invalid", NetworkNameEnvVarName)
-	ErrInvalidNetworkNamespace          = fmt.Errorf("%q environment variable is invalid", NetworkNamespaceEnvVarName)
-	ErrSourceNodeNameMissing            = fmt.Errorf("%q environment variable is missing", SourceNodeNameEnvVarName)
-	ErrInvalidSourceNodeName            = fmt.Errorf("%q environment variable is invalid", SourceNodeNameEnvVarName)
-	ErrTargetNodeNameMissing            = fmt.Errorf("%q environment variable is missing", TargetNodeNameEnvVarName)
-	ErrInvalidTargetNodeName            = fmt.Errorf("%q environment variable is invalid", TargetNodeNameEnvVarName)
+	ErrInvalidEnv                             = errors.New("environment is invalid")
+	ErrInvalidResultsConfigMapName            = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNameEnvVarName)
+	ErrInvalidResultsConfigMapNamespace       = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNamespaceEnvVarName)
+	ErrInvalidNetworkName                     = fmt.Errorf("%q environment variable is invalid", NetworkNameEnvVarName)
+	ErrInvalidNetworkNamespace                = fmt.Errorf("%q environment variable is invalid", NetworkNamespaceEnvVarName)
+	ErrIllegalSourceAndTargetNodesCombination = errors.New("illegal source and target nodes combination")
 )
 
 const (
@@ -74,24 +71,15 @@ func New(env map[string]string) (Config, error) {
 		return Config{}, ErrInvalidEnv
 	}
 
-	resultsConfigMapName := env[ResultsConfigMapNameEnvVarName]
-	if resultsConfigMapName == "" {
-		return Config{}, ErrInvalidResultsConfigMapName
-	}
-
-	resultsConfigMapNamespace := env[ResultsConfigMapNamespaceEnvVarName]
-	if resultsConfigMapNamespace == "" {
-		return Config{}, ErrInvalidResultsConfigMapNamespace
-	}
-
-	networkName := env[NetworkNameEnvVarName]
-	if networkName == "" {
-		return Config{}, ErrInvalidNetworkName
-	}
-
-	networkNamespace := env[NetworkNamespaceEnvVarName]
-	if networkNamespace == "" {
-		return Config{}, ErrInvalidNetworkNamespace
+	newConfig := Config{
+		ResultsConfigMapName:      env[ResultsConfigMapNameEnvVarName],
+		ResultsConfigMapNamespace: env[ResultsConfigMapNamespaceEnvVarName],
+		CheckupParameters: CheckupParameters{
+			NetworkAttachmentDefinitionName:      env[NetworkNameEnvVarName],
+			NetworkAttachmentDefinitionNamespace: env[NetworkNamespaceEnvVarName],
+			TargetNodeName:                       env[TargetNodeNameEnvVarName],
+			SourceNodeName:                       env[SourceNodeNameEnvVarName],
+		},
 	}
 
 	var err error
@@ -101,6 +89,7 @@ func New(env map[string]string) (Config, error) {
 			return Config{}, fmt.Errorf("%q environment variable is invalid: %v", SampleDurationSecondsEnvVarName, err)
 		}
 	}
+	newConfig.SampleDurationSeconds = sampleDuration
 
 	desiredMaxLatency := DefaultDesiredMaxLatencyMilliseconds
 	if value, exists := env[DesiredMaxLatencyMillisecondsEnvVarName]; exists {
@@ -108,41 +97,34 @@ func New(env map[string]string) (Config, error) {
 			return Config{}, fmt.Errorf("%q environment variable is invalid: %v", DesiredMaxLatencyMillisecondsEnvVarName, err)
 		}
 	}
+	newConfig.DesiredMaxLatencyMilliseconds = desiredMaxLatency
 
-	if err := validateNodeNames(env); err != nil {
+	if err := newConfig.validate(); err != nil {
 		return Config{}, err
 	}
 
-	return Config{
-		ResultsConfigMapName:      resultsConfigMapName,
-		ResultsConfigMapNamespace: resultsConfigMapNamespace,
-		CheckupParameters: CheckupParameters{
-			NetworkAttachmentDefinitionName:      networkName,
-			NetworkAttachmentDefinitionNamespace: networkNamespace,
-			TargetNodeName:                       env[TargetNodeNameEnvVarName],
-			SourceNodeName:                       env[SourceNodeNameEnvVarName],
-			SampleDurationSeconds:                sampleDuration,
-			DesiredMaxLatencyMilliseconds:        desiredMaxLatency,
-		},
-	}, nil
+	return newConfig, nil
 }
 
-func validateNodeNames(env map[string]string) error {
-	sourceNodeName, sourceNodeNameExists := env[SourceNodeNameEnvVarName]
-	targetNodeName, targetNodeNameExists := env[TargetNodeNameEnvVarName]
+func (c Config) validate() error {
+	if c.ResultsConfigMapName == "" {
+		return ErrInvalidResultsConfigMapName
+	}
 
-	switch {
-	case !sourceNodeNameExists && targetNodeNameExists:
-		return ErrSourceNodeNameMissing
-	case !targetNodeNameExists && sourceNodeNameExists:
-		return ErrTargetNodeNameMissing
-	case sourceNodeNameExists && targetNodeNameExists:
-		if sourceNodeName == "" {
-			return ErrInvalidSourceNodeName
-		}
-		if targetNodeName == "" {
-			return ErrInvalidTargetNodeName
-		}
+	if c.ResultsConfigMapNamespace == "" {
+		return ErrInvalidResultsConfigMapNamespace
+	}
+
+	if c.NetworkAttachmentDefinitionName == "" {
+		return ErrInvalidNetworkName
+	}
+
+	if c.NetworkAttachmentDefinitionNamespace == "" {
+		return ErrInvalidNetworkNamespace
+	}
+
+	if c.SourceNodeName == "" && c.TargetNodeName != "" || c.SourceNodeName != "" && c.TargetNodeName == "" {
+		return ErrIllegalSourceAndTargetNodesCombination
 	}
 
 	return nil

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
@@ -252,7 +252,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 	testCases := []configCreateFallingTestCases{
 		{
 			description:   "source node name is set but target node name isn't",
-			expectedError: config.ErrTargetNodeNameMissing,
+			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
@@ -263,7 +263,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 		},
 		{
 			description:   "target node name is set but source node name isn't",
-			expectedError: config.ErrSourceNodeNameMissing,
+			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
@@ -274,7 +274,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 		},
 		{
 			description:   "source node name is empty",
-			expectedError: config.ErrInvalidSourceNodeName,
+			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
@@ -286,7 +286,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 		},
 		{
 			description:   "target node name is empty",
-			expectedError: config.ErrInvalidTargetNodeName,
+			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
@@ -153,7 +153,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 	testCases := []configCreateFallingTestCases{
 		{
 			description:   "results ConfigMap name env var is missing",
-			expectedError: config.ErrResultsConfigMapNameMissing,
+			expectedError: config.ErrInvalidResultsConfigMapName,
 			env: map[string]string{
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -162,7 +162,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 		},
 		{
 			description:   "results ConfigMap namespace env var is missing",
-			expectedError: config.ErrResultsConfigMapNamespaceMissing,
+			expectedError: config.ErrInvalidResultsConfigMapNamespace,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName: testResultConfigMapName,
 				config.NetworkNameEnvVarName:          testNetAttachDefName,
@@ -171,7 +171,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 		},
 		{
 			description:   "network name env var is missing",
-			expectedError: config.ErrNetworkNameMissing,
+			expectedError: config.ErrInvalidNetworkName,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
@@ -180,7 +180,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 		},
 		{
 			description:   "network namespace env var is missing",
-			expectedError: config.ErrNetworkNamespaceMissing,
+			expectedError: config.ErrInvalidNetworkNamespace,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,


### PR DESCRIPTION
Currently, it is not trivial to consume a new field in the API between the framework and the checkup due to the complexity of `config.New()`:

1. Currently, there is a distinction between the states where a mandatory environment variable is:
  - Missing
  - Invalid

In order to reduce the number of possible emitted errors by a factor of two, and to simplify the parsing code - treat all missing mandatory environment variables as invalid.

2. Simplify the parsing and validation of the checkup's configuration:
  - Read all string environment variables in one go.
  - Parse all string environment variables in one go.
  - Replace multiple errors related to source and target nodes with one error.

  Keep the parsing and validation of integer fields as-is.