### PR TITLE
kubevirt-vm-latency: Simplify latency check VMI create function

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -79,7 +79,6 @@ func (c *checkup) Setup(ctx context.Context) error {
 
 		defaultSetupTimeout = time.Minute * 10
 
-		networkName   = "net0"
 		sourceVmiMac  = "02:00:00:01:00:01"
 		sourceVmiCidr = "192.168.100.10/24"
 		targetVmiMac  = "02:00:00:02:00:02"
@@ -93,8 +92,8 @@ func (c *checkup) Setup(ctx context.Context) error {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
 
-	sourceVmi := newLatencyCheckVmi(SourceVmiName, c.params.SourceNodeName, networkName, netAttachDef, sourceVmiMac, sourceVmiCidr)
-	targetVmi := newLatencyCheckVmi(TargetVmiName, c.params.TargetNodeName, networkName, netAttachDef, targetVmiMac, targetVmiCidr)
+	sourceVmi := newLatencyCheckVmi(SourceVmiName, c.params.SourceNodeName, netAttachDef, sourceVmiMac, sourceVmiCidr)
+	targetVmi := newLatencyCheckVmi(TargetVmiName, c.params.TargetNodeName, netAttachDef, targetVmiMac, targetVmiCidr)
 
 	if err = vmi.Start(c.client, c.namespace, sourceVmi); err != nil {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
@@ -120,9 +119,11 @@ func (c *checkup) Setup(ctx context.Context) error {
 
 func newLatencyCheckVmi(
 	name,
-	nodeName,
-	networkName string, netAttachDef *netattdefv1.NetworkAttachmentDefinition,
+	nodeName string,
+	netAttachDef *netattdefv1.NetworkAttachmentDefinition,
 	macAddress, cidr string) *kvcorev1.VirtualMachineInstance {
+	const networkName = "net0"
+
 	vmLabel := vmi.Label{Key: LabelLatencyCheckVM, Value: ""}
 	var affinity *k8scorev1.Affinity
 	if nodeName != "" {

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -124,13 +124,6 @@ func newLatencyCheckVmi(
 	nodeName,
 	networkName string, netAttachDef *netattdefv1.NetworkAttachmentDefinition,
 	macAddress, cidr string) *kvcorev1.VirtualMachineInstance {
-	networkData, _ := vmi.NewNetworkData(
-		vmi.WithEthernet(networkName,
-			vmi.WithAddresses(cidr),
-			vmi.WithMatchingMAC(macAddress),
-		),
-	)
-
 	var vmiInterface kvcorev1.Interface
 	if netattachdef.IsSriov(netAttachDef) {
 		vmiInterface = vmi.NewInterface(networkName, vmi.WithMacAddress(macAddress), vmi.WithSriovBinding())
@@ -151,7 +144,12 @@ func newLatencyCheckVmi(
 		vmi.WithAffinity(affinity),
 		vmi.WithMultusNetwork(networkName, netAttachDef.Namespace+"/"+netAttachDef.Name),
 		vmi.WithInterface(vmiInterface),
-		vmi.WithCloudInitNoCloudNetworkData(networkData),
+		vmi.WithCloudInitNoCloudNetworkData(
+			vmi.WithEthernet(networkName,
+				vmi.WithAddresses(cidr),
+				vmi.WithMatchingMAC(macAddress),
+			),
+		),
 	)
 }
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
@@ -110,8 +110,10 @@ func multusNetwork(name, netAttachDefName string) kvcorev1.Network {
 	}
 }
 
-// WithCloudInitNoCloudNetworkData adds cloud-init no-cloud network data.
-func WithCloudInitNoCloudNetworkData(networkData string) Option {
+// WithCloudInitNoCloudNetworkData adds cloud-init no-cloud network data with the given options.
+func WithCloudInitNoCloudNetworkData(opts ...networkDataOption) Option {
+	networkData, _ := NewNetworkData(opts...)
+
 	return func(vmi *kvcorev1.VirtualMachineInstance) {
 		const volumeName = "cloudinit"
 		vmi.Spec.Volumes = append(vmi.Spec.Volumes, newCloudinitVolumeWithNetworkData(volumeName, networkData))


### PR DESCRIPTION
Simplify the latency check VMI creation function [1] by moving the logic of some of the VMI spec configurations to the `vmi` package.
Also, moving the network name const closer to where it is used ([1] function).

[1]  https://github.com/kiagnose/kiagnose/blob/c8bb5e066d1b50025e1741097b6b7a697e5487f9/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go#L122