### PR TITLE
vmlatency, checkup: Name VMIs after the checkup's name

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
@@ -40,6 +40,7 @@ import (
 
 const (
 	testNamespace             = "default"
+	testCheckupName           = "mycheckup"
 	testNetAttachDefName      = "blue-net"
 	testSampleDurationSeconds = 1
 	testTimeout               = time.Nanosecond
@@ -50,7 +51,7 @@ func TestCheckupSetupShouldFailWhen(t *testing.T) {
 		expectedError := errors.New("get netAttachDef test error")
 		testClient := newTestClient()
 		testClient.failGetNetAttachDef = expectedError
-		testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+		testCheckup := checkup.New(testClient, testNamespace, testCheckupName, newTestsCheckupParameters(), &checkerStub{})
 
 		assert.NoError(t, testCheckup.Preflight())
 		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedError.Error())
@@ -61,7 +62,7 @@ func TestCheckupSetupShouldFailWhen(t *testing.T) {
 		testClient := newTestClient()
 		testClient.failCreateVmi = expectedError
 		testClient.returnNetAttachDef = &netattdefv1.NetworkAttachmentDefinition{}
-		testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+		testCheckup := checkup.New(testClient, testNamespace, testCheckupName, newTestsCheckupParameters(), &checkerStub{})
 
 		assert.NoError(t, testCheckup.Preflight())
 		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedError.Error())
@@ -72,7 +73,7 @@ func TestCheckupSetupShouldFailWhen(t *testing.T) {
 		testClient := newTestClient()
 		testClient.failGetVmi = expectedError
 		testClient.returnNetAttachDef = &netattdefv1.NetworkAttachmentDefinition{}
-		testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+		testCheckup := checkup.New(testClient, testNamespace, testCheckupName, newTestsCheckupParameters(), &checkerStub{})
 
 		testCtx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
@@ -86,7 +87,7 @@ func TestCheckupTeardownShouldFailWhen(t *testing.T) {
 	t.Run("failed to delete a VM", func(t *testing.T) {
 		testClient := newTestClient()
 		testClient.returnNetAttachDef = &netattdefv1.NetworkAttachmentDefinition{}
-		testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+		testCheckup := checkup.New(testClient, testNamespace, testCheckupName, newTestsCheckupParameters(), &checkerStub{})
 
 		testCtx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
@@ -103,7 +104,7 @@ func TestCheckupTeardownShouldFailWhen(t *testing.T) {
 	t.Run("VMs were not disposed before timeout expiration", func(t *testing.T) {
 		testClient := newTestClient()
 		testClient.returnNetAttachDef = &netattdefv1.NetworkAttachmentDefinition{}
-		testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+		testCheckup := checkup.New(testClient, testNamespace, testCheckupName, newTestsCheckupParameters(), &checkerStub{})
 
 		assert.NoError(t, testCheckup.Preflight())
 		assert.NoError(t, testCheckup.Setup(context.Background()))
@@ -142,7 +143,7 @@ func TestCheckupSetupShouldCreateVMsWith(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			testClient := newTestClient()
 			testClient.returnNetAttachDef = testCase.netAttachDef
-			testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+			testCheckup := checkup.New(testClient, testNamespace, testCheckupName, newTestsCheckupParameters(), &checkerStub{})
 
 			assert.NoError(t, testCheckup.Preflight())
 			assert.NoError(t, testCheckup.Setup(context.Background()))
@@ -159,14 +160,18 @@ func TestCheckupSetupShouldCreateVMsWithPodAntiAffinity(t *testing.T) {
 	t.Run("when source and target nodes names are not specified", func(t *testing.T) {
 		testClient := newTestClient()
 		testClient.returnNetAttachDef = newTestNetAttachDef("")
-		testCheckup := checkup.New(testClient, testNamespace, config.CheckupParameters{}, &checkerStub{})
+		testCheckup := checkup.New(testClient, testNamespace, testCheckupName, config.CheckupParameters{}, &checkerStub{})
 
 		assert.NoError(t, testCheckup.Preflight())
 		assert.NoError(t, testCheckup.Setup(context.Background()))
-		assertVmiPodAntiAffinityExist(t, testClient, checkup.SourceVmiName)
-		assertVmiPodAntiAffinityExist(t, testClient, checkup.TargetVmiName)
-		assertVmiNodeAffinityNotExist(t, testClient, checkup.SourceVmiName)
-		assertVmiNodeAffinityNotExist(t, testClient, checkup.TargetVmiName)
+
+		sourceVMIName := checkup.NameVMI(testCheckupName, checkup.SourceVmiNameSuffix)
+		targetVMIName := checkup.NameVMI(testCheckupName, checkup.TargetVmiNameSuffix)
+
+		assertVmiPodAntiAffinityExist(t, testClient, sourceVMIName)
+		assertVmiPodAntiAffinityExist(t, testClient, targetVMIName)
+		assertVmiNodeAffinityNotExist(t, testClient, sourceVMIName)
+		assertVmiNodeAffinityNotExist(t, testClient, targetVMIName)
 	})
 }
 
@@ -179,14 +184,18 @@ func TestCheckupSetupShouldCreateVMsWithNodeAffinity(t *testing.T) {
 		testClient := newTestClient()
 		testClient.returnNetAttachDef = newTestNetAttachDef("blah")
 		testCheckupParams := config.CheckupParameters{SourceNodeName: testSourceNode, TargetNodeName: testTargetNode}
-		testCheckup := checkup.New(testClient, testNamespace, testCheckupParams, &checkerStub{})
+		testCheckup := checkup.New(testClient, testNamespace, testCheckupName, testCheckupParams, &checkerStub{})
 
 		assert.NoError(t, testCheckup.Preflight())
 		assert.NoError(t, testCheckup.Setup(context.Background()))
-		assertVmiNodeAffinityExist(t, testClient, checkup.SourceVmiName, testSourceNode)
-		assertVmiNodeAffinityExist(t, testClient, checkup.TargetVmiName, testTargetNode)
-		assertVmiPodAntiAffinityNotExist(t, testClient, checkup.SourceVmiName)
-		assertVmiPodAntiAffinityNotExist(t, testClient, checkup.TargetVmiName)
+
+		sourceVMIName := checkup.NameVMI(testCheckupName, checkup.SourceVmiNameSuffix)
+		targetVMIName := checkup.NameVMI(testCheckupName, checkup.TargetVmiNameSuffix)
+
+		assertVmiNodeAffinityExist(t, testClient, sourceVMIName, testSourceNode)
+		assertVmiNodeAffinityExist(t, testClient, targetVMIName, testTargetNode)
+		assertVmiPodAntiAffinityNotExist(t, testClient, sourceVMIName)
+		assertVmiPodAntiAffinityNotExist(t, testClient, targetVMIName)
 	})
 }
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
@@ -54,13 +54,9 @@ type Config struct {
 
 var (
 	ErrInvalidEnv                       = errors.New("environment is invalid")
-	ErrResultsConfigMapNameMissing      = fmt.Errorf("%q environment variable is missing", ResultsConfigMapNameEnvVarName)
 	ErrInvalidResultsConfigMapName      = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNameEnvVarName)
-	ErrResultsConfigMapNamespaceMissing = fmt.Errorf("%q environment variable is missing", ResultsConfigMapNamespaceEnvVarName)
 	ErrInvalidResultsConfigMapNamespace = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNamespaceEnvVarName)
-	ErrNetworkNameMissing               = fmt.Errorf("%q environment variable is missing", NetworkNameEnvVarName)
 	ErrInvalidNetworkName               = fmt.Errorf("%q environment variable is invalid", NetworkNameEnvVarName)
-	ErrNetworkNamespaceMissing          = fmt.Errorf("%q environment variable is missing", NetworkNamespaceEnvVarName)
 	ErrInvalidNetworkNamespace          = fmt.Errorf("%q environment variable is invalid", NetworkNamespaceEnvVarName)
 	ErrSourceNodeNameMissing            = fmt.Errorf("%q environment variable is missing", SourceNodeNameEnvVarName)
 	ErrInvalidSourceNodeName            = fmt.Errorf("%q environment variable is invalid", SourceNodeNameEnvVarName)
@@ -78,34 +74,22 @@ func New(env map[string]string) (Config, error) {
 		return Config{}, ErrInvalidEnv
 	}
 
-	resultsConfigMapName, exists := env[ResultsConfigMapNameEnvVarName]
-	if !exists {
-		return Config{}, ErrResultsConfigMapNameMissing
-	}
+	resultsConfigMapName := env[ResultsConfigMapNameEnvVarName]
 	if resultsConfigMapName == "" {
 		return Config{}, ErrInvalidResultsConfigMapName
 	}
 
-	resultsConfigMapNamespace, exists := env[ResultsConfigMapNamespaceEnvVarName]
-	if !exists {
-		return Config{}, ErrResultsConfigMapNamespaceMissing
-	}
+	resultsConfigMapNamespace := env[ResultsConfigMapNamespaceEnvVarName]
 	if resultsConfigMapNamespace == "" {
 		return Config{}, ErrInvalidResultsConfigMapNamespace
 	}
 
-	networkName, exists := env[NetworkNameEnvVarName]
-	if !exists {
-		return Config{}, ErrNetworkNameMissing
-	}
+	networkName := env[NetworkNameEnvVarName]
 	if networkName == "" {
 		return Config{}, ErrInvalidNetworkName
 	}
 
-	networkNamespace, exists := env[NetworkNamespaceEnvVarName]
-	if !exists {
-		return Config{}, ErrNetworkNamespaceMissing
-	}
+	networkNamespace := env[NetworkNamespaceEnvVarName]
 	if networkNamespace == "" {
 		return Config{}, ErrInvalidNetworkNamespace
 	}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	CheckupNameEnvVarName                   = "CHECKUP_NAME"
 	ResultsConfigMapNamespaceEnvVarName     = "RESULT_CONFIGMAP_NAMESPACE"
 	ResultsConfigMapNameEnvVarName          = "RESULT_CONFIGMAP_NAME"
 	NetworkNamespaceEnvVarName              = "NETWORK_ATTACHMENT_DEFINITION_NAMESPACE"
@@ -47,6 +48,7 @@ type CheckupParameters struct {
 }
 
 type Config struct {
+	CheckupName               string
 	ResultsConfigMapName      string
 	ResultsConfigMapNamespace string
 	CheckupParameters
@@ -54,6 +56,7 @@ type Config struct {
 
 var (
 	ErrInvalidEnv                             = errors.New("environment is invalid")
+	ErrInvalidCheckupName                     = fmt.Errorf("%q environment variable is invalid", CheckupNameEnvVarName)
 	ErrInvalidResultsConfigMapName            = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNameEnvVarName)
 	ErrInvalidResultsConfigMapNamespace       = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNamespaceEnvVarName)
 	ErrInvalidNetworkName                     = fmt.Errorf("%q environment variable is invalid", NetworkNameEnvVarName)
@@ -72,6 +75,7 @@ func New(env map[string]string) (Config, error) {
 	}
 
 	newConfig := Config{
+		CheckupName:               env[CheckupNameEnvVarName],
 		ResultsConfigMapName:      env[ResultsConfigMapNameEnvVarName],
 		ResultsConfigMapNamespace: env[ResultsConfigMapNamespaceEnvVarName],
 		CheckupParameters: CheckupParameters{
@@ -107,6 +111,10 @@ func New(env map[string]string) (Config, error) {
 }
 
 func (c Config) validate() error {
+	if c.CheckupName == "" {
+		return ErrInvalidCheckupName
+	}
+
 	if c.ResultsConfigMapName == "" {
 		return ErrInvalidResultsConfigMapName
 	}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
@@ -36,6 +36,7 @@ type configCreateTestCases struct {
 }
 
 const (
+	testCheckupName                   = "mytest"
 	testNamespace                     = "default"
 	testResultConfigMapName           = "results"
 	testNetAttachDefName              = "blue-net"
@@ -50,6 +51,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 		{
 			description: "set default sample duration when env var is missing",
 			env: map[string]string{
+				config.CheckupNameEnvVarName:                   testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:          testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName:     testNamespace,
 				config.NetworkNameEnvVarName:                   testNetAttachDefName,
@@ -63,6 +65,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 					NetworkAttachmentDefinitionNamespace: testNamespace,
 					DesiredMaxLatencyMilliseconds:        testDesiredMaxLatencyMilliseconds,
 				},
+				CheckupName:               testCheckupName,
 				ResultsConfigMapName:      testResultConfigMapName,
 				ResultsConfigMapNamespace: testNamespace,
 			},
@@ -70,6 +73,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 		{
 			description: "set default desired max latency when env var is missing",
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -83,6 +87,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 					NetworkAttachmentDefinitionNamespace: testNamespace,
 					SampleDurationSeconds:                testSampleDurationSeconds,
 				},
+				CheckupName:               testCheckupName,
 				ResultsConfigMapName:      testResultConfigMapName,
 				ResultsConfigMapNamespace: testNamespace,
 			},
@@ -90,6 +95,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 		{
 			description: "set source and target nodes when both are specified",
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -107,6 +113,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 					SourceNodeName:                       testSourceNodeName,
 					TargetNodeName:                       testTargetNodeName,
 				},
+				CheckupName:               testCheckupName,
 				ResultsConfigMapName:      testResultConfigMapName,
 				ResultsConfigMapNamespace: testNamespace,
 			},
@@ -152,9 +159,20 @@ func TestCreateConfigFromEnvShouldFailWhen(t *testing.T) {
 func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.T) {
 	testCases := []configCreateFallingTestCases{
 		{
+			description:   "Checkup name env var is missing",
+			expectedError: config.ErrInvalidCheckupName,
+			env: map[string]string{
+				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
+				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
+				config.NetworkNameEnvVarName:               testNetAttachDefName,
+				config.NetworkNamespaceEnvVarName:          testNamespace,
+			},
+		},
+		{
 			description:   "results ConfigMap name env var is missing",
 			expectedError: config.ErrInvalidResultsConfigMapName,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
 				config.NetworkNamespaceEnvVarName:          testNamespace,
@@ -164,6 +182,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 			description:   "results ConfigMap namespace env var is missing",
 			expectedError: config.ErrInvalidResultsConfigMapNamespace,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:          testCheckupName,
 				config.ResultsConfigMapNameEnvVarName: testResultConfigMapName,
 				config.NetworkNameEnvVarName:          testNetAttachDefName,
 				config.NetworkNamespaceEnvVarName:     testNamespace,
@@ -173,6 +192,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 			description:   "network name env var is missing",
 			expectedError: config.ErrInvalidNetworkName,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNamespaceEnvVarName:          testNamespace,
@@ -182,6 +202,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 			description:   "network namespace env var is missing",
 			expectedError: config.ErrInvalidNetworkNamespace,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -200,9 +221,21 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreInvalid(t *testing.T) {
 	testCases := []configCreateFallingTestCases{
 		{
+			description:   "Checkup name env var value is not valid",
+			expectedError: config.ErrInvalidCheckupName,
+			env: map[string]string{
+				config.CheckupNameEnvVarName:               "",
+				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
+				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
+				config.NetworkNameEnvVarName:               testNetAttachDefName,
+				config.NetworkNamespaceEnvVarName:          testNamespace,
+			},
+		},
+		{
 			description:   "results ConfigMap name env var value is not valid",
 			expectedError: config.ErrInvalidResultsConfigMapName,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      "",
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -213,6 +246,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreInvalid(t *testing.
 			description:   "results ConfigMap namespace env var value is not valid",
 			expectedError: config.ErrInvalidResultsConfigMapNamespace,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: "",
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -223,6 +257,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreInvalid(t *testing.
 			description:   "network name env var value is not valid",
 			expectedError: config.ErrInvalidNetworkName,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               "",
@@ -233,6 +268,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreInvalid(t *testing.
 			description:   "network namespace env var value is not valid",
 			expectedError: config.ErrInvalidNetworkNamespace,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -254,6 +290,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 			description:   "source node name is set but target node name isn't",
 			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -265,6 +302,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 			description:   "target node name is set but source node name isn't",
 			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -276,6 +314,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 			description:   "source node name is empty",
 			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -288,6 +327,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 			description:   "target node name is empty",
 			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -311,6 +351,7 @@ func TestCreateConfigShouldFailWhenIntegerEnvVarsAreInvalid(t *testing.T) {
 			description:   "sample duration is not valid integer",
 			expectedError: strconv.ErrSyntax,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:               testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -322,6 +363,7 @@ func TestCreateConfigShouldFailWhenIntegerEnvVarsAreInvalid(t *testing.T) {
 			description:   "desired max latency is too big",
 			expectedError: strconv.ErrRange,
 			env: map[string]string{
+				config.CheckupNameEnvVarName:                   testCheckupName,
 				config.ResultsConfigMapNameEnvVarName:          testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName:     testNamespace,
 				config.NetworkNameEnvVarName:                   testNetAttachDefName,

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
@@ -252,7 +252,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 	testCases := []configCreateFallingTestCases{
 		{
 			description:   "source node name is set but target node name isn't",
-			expectedError: config.ErrTargetNodeNameMissing,
+			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
@@ -263,7 +263,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 		},
 		{
 			description:   "target node name is set but source node name isn't",
-			expectedError: config.ErrSourceNodeNameMissing,
+			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
@@ -274,7 +274,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 		},
 		{
 			description:   "source node name is empty",
-			expectedError: config.ErrInvalidSourceNodeName,
+			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
@@ -286,7 +286,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 		},
 		{
 			description:   "target node name is empty",
-			expectedError: config.ErrInvalidTargetNodeName,
+			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
@@ -153,7 +153,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 	testCases := []configCreateFallingTestCases{
 		{
 			description:   "results ConfigMap name env var is missing",
-			expectedError: config.ErrResultsConfigMapNameMissing,
+			expectedError: config.ErrInvalidResultsConfigMapName,
 			env: map[string]string{
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -162,7 +162,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 		},
 		{
 			description:   "results ConfigMap namespace env var is missing",
-			expectedError: config.ErrResultsConfigMapNamespaceMissing,
+			expectedError: config.ErrInvalidResultsConfigMapNamespace,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName: testResultConfigMapName,
 				config.NetworkNameEnvVarName:          testNetAttachDefName,
@@ -171,7 +171,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 		},
 		{
 			description:   "network name env var is missing",
-			expectedError: config.ErrNetworkNameMissing,
+			expectedError: config.ErrInvalidNetworkName,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
@@ -180,7 +180,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 		},
 		{
 			description:   "network namespace env var is missing",
-			expectedError: config.ErrNetworkNamespaceMissing,
+			expectedError: config.ErrInvalidNetworkNamespace,
 			env: map[string]string{
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -42,11 +42,14 @@ import (
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/status"
 )
 
+const testCheckupName = "mycheckup"
+
 func TestLauncherShouldFail(t *testing.T) {
 	testClient := newFakeClient()
 	testCheckup := checkup.New(
 		testClient,
 		k8scorev1.NamespaceDefault,
+		testCheckupName,
 		config.CheckupParameters{},
 		&checkerStub{checkFailure: errorCheck},
 	)
@@ -60,6 +63,7 @@ func TestLauncherShouldRunSuccessfully(t *testing.T) {
 	testCheckup := checkup.New(
 		testClient,
 		k8scorev1.NamespaceDefault,
+		testCheckupName,
 		config.CheckupParameters{},
 		&checkerStub{},
 	)
@@ -160,6 +164,7 @@ func TestLauncherShouldSuccessfullyProduceStatusResults(t *testing.T) {
 	testCheckup := checkup.New(
 		testClient,
 		k8scorev1.NamespaceDefault,
+		testCheckupName,
 		config.CheckupParameters{
 			SourceNodeName: sourceNodeName,
 			TargetNodeName: targetNodeName,

--- a/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
@@ -40,7 +40,7 @@ func Run(env map[string]string, namespace string) error {
 	}
 
 	l := launcher.New(
-		checkup.New(c, namespace, cfg.CheckupParameters, latency.New(c)),
+		checkup.New(c, namespace, cfg.CheckupName, cfg.CheckupParameters, latency.New(c)),
 		reporter.New(c, cfg.ResultsConfigMapNamespace, cfg.ResultsConfigMapName),
 	)
 	return l.Run()

--- a/docs/checkup_api.md
+++ b/docs/checkup_api.md
@@ -34,6 +34,7 @@ The checkup should expect the following environment variables:
 
 | Environment Variable Name    | Description                 | Remarks                                                      |
 |------------------------------|-----------------------------|--------------------------------------------------------------|
+| `CHECKUP_NAME`               | Checkup Name                | Could be used by a checkup to name child objects             |
 | `RESULT_CONFIGMAP_NAMESPACE` | Results ConfigMap Namespace | Used by the underlying Pod need to write the checkup results |
 | `RESULT_CONFIGMAP_NAME`      | Results ConfigMap name      | Used by the underlying Pod need to write the checkup results |
 

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -50,6 +50,7 @@ type Checkup struct {
 }
 
 const (
+	NameEnvVarName                      = "CHECKUP_NAME"
 	ResultsConfigMapNameEnvVarName      = "RESULT_CONFIGMAP_NAME"
 	ResultsConfigMapNameEnvVarNamespace = "RESULT_CONFIGMAP_NAMESPACE"
 )
@@ -67,6 +68,7 @@ func New(c kubernetes.Interface, targetNsName, name string, checkupConfig *confi
 	}
 
 	checkupEnvVars := []corev1.EnvVar{
+		{Name: NameEnvVarName, Value: name},
 		{Name: ResultsConfigMapNameEnvVarName, Value: resultsConfigMapName},
 		{Name: ResultsConfigMapNameEnvVarNamespace, Value: targetNsName},
 	}

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -266,6 +266,7 @@ func TestCheckupRunShouldCreateAJob(t *testing.T) {
 
 			expectedResultsConfigMapName := checkup.NameResultsConfigMap(testCheckupName)
 			expectedEnvVars := []corev1.EnvVar{
+				{Name: checkup.NameEnvVarName, Value: testCheckupName},
 				{Name: checkup.ResultsConfigMapNameEnvVarName, Value: expectedResultsConfigMapName},
 				{Name: checkup.ResultsConfigMapNameEnvVarNamespace, Value: testTargetNs},
 			}


### PR DESCRIPTION
Currently, the VMIs created by the VM latency checkup has hard-coded names.
This prevents execution of multiple instances of this checkup in parallel (for more details see issue #164).

1. Add a new `CHECKUP_NAME` environment variable in the API between the framework and the checkup.
2. Use it to create the names of the VMIs in VM latency checkup.

Depends on PR #169.


