### PR TITLE
vmlatency: Use checkup UID as label value

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
@@ -39,6 +39,7 @@ import (
 )
 
 const (
+	testCheckupUID            = "0123456789"
 	testNamespace             = "default"
 	testNetAttachDefName      = "blue-net"
 	testSampleDurationSeconds = 1
@@ -50,7 +51,7 @@ func TestCheckupSetupShouldFailWhen(t *testing.T) {
 		expectedError := errors.New("get netAttachDef test error")
 		testClient := newTestClient()
 		testClient.failGetNetAttachDef = expectedError
-		testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, newTestsCheckupParameters(), &checkerStub{})
 
 		assert.NoError(t, testCheckup.Preflight())
 		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedError.Error())
@@ -61,7 +62,7 @@ func TestCheckupSetupShouldFailWhen(t *testing.T) {
 		testClient := newTestClient()
 		testClient.failCreateVmi = expectedError
 		testClient.returnNetAttachDef = &netattdefv1.NetworkAttachmentDefinition{}
-		testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, newTestsCheckupParameters(), &checkerStub{})
 
 		assert.NoError(t, testCheckup.Preflight())
 		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedError.Error())
@@ -72,7 +73,7 @@ func TestCheckupSetupShouldFailWhen(t *testing.T) {
 		testClient := newTestClient()
 		testClient.failGetVmi = expectedError
 		testClient.returnNetAttachDef = &netattdefv1.NetworkAttachmentDefinition{}
-		testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, newTestsCheckupParameters(), &checkerStub{})
 
 		testCtx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
@@ -86,7 +87,7 @@ func TestCheckupTeardownShouldFailWhen(t *testing.T) {
 	t.Run("failed to delete a VM", func(t *testing.T) {
 		testClient := newTestClient()
 		testClient.returnNetAttachDef = &netattdefv1.NetworkAttachmentDefinition{}
-		testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, newTestsCheckupParameters(), &checkerStub{})
 
 		testCtx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
@@ -103,7 +104,7 @@ func TestCheckupTeardownShouldFailWhen(t *testing.T) {
 	t.Run("VMs were not disposed before timeout expiration", func(t *testing.T) {
 		testClient := newTestClient()
 		testClient.returnNetAttachDef = &netattdefv1.NetworkAttachmentDefinition{}
-		testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, newTestsCheckupParameters(), &checkerStub{})
 
 		assert.NoError(t, testCheckup.Preflight())
 		assert.NoError(t, testCheckup.Setup(context.Background()))
@@ -142,7 +143,7 @@ func TestCheckupSetupShouldCreateVMsWith(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			testClient := newTestClient()
 			testClient.returnNetAttachDef = testCase.netAttachDef
-			testCheckup := checkup.New(testClient, testNamespace, newTestsCheckupParameters(), &checkerStub{})
+			testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, newTestsCheckupParameters(), &checkerStub{})
 
 			assert.NoError(t, testCheckup.Preflight())
 			assert.NoError(t, testCheckup.Setup(context.Background()))
@@ -159,7 +160,7 @@ func TestCheckupSetupShouldCreateVMsWithPodAntiAffinity(t *testing.T) {
 	t.Run("when source and target nodes names are not specified", func(t *testing.T) {
 		testClient := newTestClient()
 		testClient.returnNetAttachDef = newTestNetAttachDef("")
-		testCheckup := checkup.New(testClient, testNamespace, config.CheckupParameters{}, &checkerStub{})
+		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, config.CheckupParameters{}, &checkerStub{})
 
 		assert.NoError(t, testCheckup.Preflight())
 		assert.NoError(t, testCheckup.Setup(context.Background()))
@@ -179,7 +180,7 @@ func TestCheckupSetupShouldCreateVMsWithNodeAffinity(t *testing.T) {
 		testClient := newTestClient()
 		testClient.returnNetAttachDef = newTestNetAttachDef("blah")
 		testCheckupParams := config.CheckupParameters{SourceNodeName: testSourceNode, TargetNodeName: testTargetNode}
-		testCheckup := checkup.New(testClient, testNamespace, testCheckupParams, &checkerStub{})
+		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, testCheckupParams, &checkerStub{})
 
 		assert.NoError(t, testCheckup.Preflight())
 		assert.NoError(t, testCheckup.Setup(context.Background()))
@@ -194,7 +195,7 @@ func assertVmiPodAntiAffinityExist(t *testing.T, testClient *clientStub, vmiName
 	actualVmi, err := testClient.GetVirtualMachineInstance(testNamespace, vmiName)
 	assert.NoError(t, err)
 	assert.NotNil(t, actualVmi.Spec.Affinity.PodAntiAffinity)
-	expectedPodAntiAffinity := vmi.NewPodAntiAffinity(vmi.Label{Key: checkup.LabelLatencyCheckVM, Value: ""})
+	expectedPodAntiAffinity := vmi.NewPodAntiAffinity(vmi.Label{Key: checkup.LabelLatencyCheckUID, Value: testCheckupUID})
 	assert.Equal(t, expectedPodAntiAffinity, actualVmi.Spec.Affinity.PodAntiAffinity)
 }
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	CheckupUIDEnvVarName                    = "CHECKUP_UID"
 	ResultsConfigMapNamespaceEnvVarName     = "RESULT_CONFIGMAP_NAMESPACE"
 	ResultsConfigMapNameEnvVarName          = "RESULT_CONFIGMAP_NAME"
 	NetworkNamespaceEnvVarName              = "NETWORK_ATTACHMENT_DEFINITION_NAMESPACE"
@@ -47,6 +48,7 @@ type CheckupParameters struct {
 }
 
 type Config struct {
+	CheckupUID                string
 	ResultsConfigMapName      string
 	ResultsConfigMapNamespace string
 	CheckupParameters
@@ -54,6 +56,7 @@ type Config struct {
 
 var (
 	ErrInvalidEnv                             = errors.New("environment is invalid")
+	ErrInvalidCheckupUID                      = fmt.Errorf("%q environment variable is invalid", CheckupUIDEnvVarName)
 	ErrInvalidResultsConfigMapName            = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNameEnvVarName)
 	ErrInvalidResultsConfigMapNamespace       = fmt.Errorf("%q environment variable is invalid", ResultsConfigMapNamespaceEnvVarName)
 	ErrInvalidNetworkName                     = fmt.Errorf("%q environment variable is invalid", NetworkNameEnvVarName)
@@ -72,6 +75,7 @@ func New(env map[string]string) (Config, error) {
 	}
 
 	newConfig := Config{
+		CheckupUID:                env[CheckupUIDEnvVarName],
 		ResultsConfigMapName:      env[ResultsConfigMapNameEnvVarName],
 		ResultsConfigMapNamespace: env[ResultsConfigMapNamespaceEnvVarName],
 		CheckupParameters: CheckupParameters{
@@ -107,6 +111,10 @@ func New(env map[string]string) (Config, error) {
 }
 
 func (c Config) validate() error {
+	if c.CheckupUID == "" {
+		return ErrInvalidCheckupUID
+	}
+
 	if c.ResultsConfigMapName == "" {
 		return ErrInvalidResultsConfigMapName
 	}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
@@ -36,6 +36,7 @@ type configCreateTestCases struct {
 }
 
 const (
+	testCheckupUID                    = "0123456789"
 	testNamespace                     = "default"
 	testResultConfigMapName           = "results"
 	testNetAttachDefName              = "blue-net"
@@ -50,6 +51,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 		{
 			description: "set default sample duration when env var is missing",
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                    testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:          testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName:     testNamespace,
 				config.NetworkNameEnvVarName:                   testNetAttachDefName,
@@ -63,6 +65,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 					NetworkAttachmentDefinitionNamespace: testNamespace,
 					DesiredMaxLatencyMilliseconds:        testDesiredMaxLatencyMilliseconds,
 				},
+				CheckupUID:                testCheckupUID,
 				ResultsConfigMapName:      testResultConfigMapName,
 				ResultsConfigMapNamespace: testNamespace,
 			},
@@ -70,6 +73,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 		{
 			description: "set default desired max latency when env var is missing",
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -83,6 +87,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 					NetworkAttachmentDefinitionNamespace: testNamespace,
 					SampleDurationSeconds:                testSampleDurationSeconds,
 				},
+				CheckupUID:                testCheckupUID,
 				ResultsConfigMapName:      testResultConfigMapName,
 				ResultsConfigMapNamespace: testNamespace,
 			},
@@ -90,6 +95,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 		{
 			description: "set source and target nodes when both are specified",
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -107,6 +113,7 @@ func TestCreateConfigFromEnvShould(t *testing.T) {
 					SourceNodeName:                       testSourceNodeName,
 					TargetNodeName:                       testTargetNodeName,
 				},
+				CheckupUID:                testCheckupUID,
 				ResultsConfigMapName:      testResultConfigMapName,
 				ResultsConfigMapNamespace: testNamespace,
 			},
@@ -152,9 +159,20 @@ func TestCreateConfigFromEnvShouldFailWhen(t *testing.T) {
 func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.T) {
 	testCases := []configCreateFallingTestCases{
 		{
+			description:   "Checkup UID env var is missing",
+			expectedError: config.ErrInvalidCheckupUID,
+			env: map[string]string{
+				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
+				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
+				config.NetworkNameEnvVarName:               testNetAttachDefName,
+				config.NetworkNamespaceEnvVarName:          testNamespace,
+			},
+		},
+		{
 			description:   "results ConfigMap name env var is missing",
 			expectedError: config.ErrInvalidResultsConfigMapName,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
 				config.NetworkNamespaceEnvVarName:          testNamespace,
@@ -164,6 +182,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 			description:   "results ConfigMap namespace env var is missing",
 			expectedError: config.ErrInvalidResultsConfigMapNamespace,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:           testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName: testResultConfigMapName,
 				config.NetworkNameEnvVarName:          testNetAttachDefName,
 				config.NetworkNamespaceEnvVarName:     testNamespace,
@@ -173,6 +192,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 			description:   "network name env var is missing",
 			expectedError: config.ErrInvalidNetworkName,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNamespaceEnvVarName:          testNamespace,
@@ -182,6 +202,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 			description:   "network namespace env var is missing",
 			expectedError: config.ErrInvalidNetworkNamespace,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -200,9 +221,21 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreMissing(t *testing.
 func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreInvalid(t *testing.T) {
 	testCases := []configCreateFallingTestCases{
 		{
+			description:   "Checkup UID env var value is not valid",
+			expectedError: config.ErrInvalidCheckupUID,
+			env: map[string]string{
+				config.CheckupUIDEnvVarName:                "",
+				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
+				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
+				config.NetworkNameEnvVarName:               testNetAttachDefName,
+				config.NetworkNamespaceEnvVarName:          testNamespace,
+			},
+		},
+		{
 			description:   "results ConfigMap name env var value is not valid",
 			expectedError: config.ErrInvalidResultsConfigMapName,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      "",
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -213,6 +246,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreInvalid(t *testing.
 			description:   "results ConfigMap namespace env var value is not valid",
 			expectedError: config.ErrInvalidResultsConfigMapNamespace,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: "",
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -223,6 +257,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreInvalid(t *testing.
 			description:   "network name env var value is not valid",
 			expectedError: config.ErrInvalidNetworkName,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               "",
@@ -233,6 +268,7 @@ func TestCreateConfigFromEnvShouldFailWhenMandatoryEnvVarsAreInvalid(t *testing.
 			description:   "network namespace env var value is not valid",
 			expectedError: config.ErrInvalidNetworkNamespace,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -254,6 +290,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 			description:   "source node name is set but target node name isn't",
 			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -265,6 +302,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 			description:   "target node name is set but source node name isn't",
 			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -276,6 +314,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 			description:   "source node name is empty",
 			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -288,6 +327,7 @@ func TestCreateConfigFromEnvShouldFailWhenNodeNames(t *testing.T) {
 			description:   "target node name is empty",
 			expectedError: config.ErrIllegalSourceAndTargetNodesCombination,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -311,6 +351,7 @@ func TestCreateConfigShouldFailWhenIntegerEnvVarsAreInvalid(t *testing.T) {
 			description:   "sample duration is not valid integer",
 			expectedError: strconv.ErrSyntax,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:      testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName: testNamespace,
 				config.NetworkNameEnvVarName:               testNetAttachDefName,
@@ -322,6 +363,7 @@ func TestCreateConfigShouldFailWhenIntegerEnvVarsAreInvalid(t *testing.T) {
 			description:   "desired max latency is too big",
 			expectedError: strconv.ErrRange,
 			env: map[string]string{
+				config.CheckupUIDEnvVarName:                    testCheckupUID,
 				config.ResultsConfigMapNameEnvVarName:          testResultConfigMapName,
 				config.ResultsConfigMapNamespaceEnvVarName:     testNamespace,
 				config.NetworkNameEnvVarName:                   testNetAttachDefName,

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -42,10 +42,13 @@ import (
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/status"
 )
 
+const testCheckupUID = "0123456789"
+
 func TestLauncherShouldFail(t *testing.T) {
 	testClient := newFakeClient()
 	testCheckup := checkup.New(
 		testClient,
+		testCheckupUID,
 		k8scorev1.NamespaceDefault,
 		config.CheckupParameters{},
 		&checkerStub{checkFailure: errorCheck},
@@ -59,6 +62,7 @@ func TestLauncherShouldRunSuccessfully(t *testing.T) {
 	testClient := newFakeClient()
 	testCheckup := checkup.New(
 		testClient,
+		testCheckupUID,
 		k8scorev1.NamespaceDefault,
 		config.CheckupParameters{},
 		&checkerStub{},
@@ -159,6 +163,7 @@ func TestLauncherShouldSuccessfullyProduceStatusResults(t *testing.T) {
 	testReporter := reporter.New(testClient, k8scorev1.NamespaceDefault, testConfigMapName)
 	testCheckup := checkup.New(
 		testClient,
+		testCheckupUID,
 		k8scorev1.NamespaceDefault,
 		config.CheckupParameters{
 			SourceNodeName: sourceNodeName,

--- a/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
@@ -40,7 +40,7 @@ func Run(env map[string]string, namespace string) error {
 	}
 
 	l := launcher.New(
-		checkup.New(c, namespace, cfg.CheckupParameters, latency.New(c)),
+		checkup.New(c, cfg.CheckupUID, namespace, cfg.CheckupParameters, latency.New(c)),
 		reporter.New(c, cfg.ResultsConfigMapNamespace, cfg.ResultsConfigMapName),
 	)
 	return l.Run()

--- a/docs/checkup_api.md
+++ b/docs/checkup_api.md
@@ -34,6 +34,7 @@ The checkup should expect the following environment variables:
 
 | Environment Variable Name    | Description                 | Remarks                                                      |
 |------------------------------|-----------------------------|--------------------------------------------------------------|
+| `CHECKUP_UID`                | Checkup UID                 | Could be used by a checkup to name child objects             |
 | `RESULT_CONFIGMAP_NAMESPACE` | Results ConfigMap Namespace | Used by the underlying Pod need to write the checkup results |
 | `RESULT_CONFIGMAP_NAME`      | Results ConfigMap name      | Used by the underlying Pod need to write the checkup results |
 

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -50,6 +50,7 @@ type Checkup struct {
 }
 
 const (
+	UIDEnvVarName                       = "CHECKUP_UID"
 	ResultsConfigMapNameEnvVarName      = "RESULT_CONFIGMAP_NAME"
 	ResultsConfigMapNameEnvVarNamespace = "RESULT_CONFIGMAP_NAMESPACE"
 )
@@ -67,6 +68,7 @@ func New(c kubernetes.Interface, targetNsName, name string, checkupConfig *confi
 	}
 
 	checkupEnvVars := []corev1.EnvVar{
+		{Name: UIDEnvVarName, Value: checkupConfig.UID},
 		{Name: ResultsConfigMapNameEnvVarName, Value: resultsConfigMapName},
 		{Name: ResultsConfigMapNameEnvVarNamespace, Value: targetNsName},
 	}

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -56,6 +56,7 @@ const (
 
 	testTargetNs           = "target-ns"
 	testCheckupName        = "checkup1"
+	testCheckupUID         = "0123456789"
 	testImage              = "framework:v1"
 	testTimeout            = time.Minute
 	testServiceAccountName = "test-sa"
@@ -89,6 +90,7 @@ func TestSetupInTargetNamespaceShouldSucceedWith(t *testing.T) {
 				testTargetNs,
 				testCheckupName,
 				&config.Config{
+					UID:                testCheckupUID,
 					Image:              testImage,
 					Timeout:            testTimeout,
 					ServiceAccountName: testServiceAccountName,
@@ -137,7 +139,7 @@ func TestSetupInTargetNamespaceShouldFailWhen(t *testing.T) {
 				testClient,
 				testTargetNs,
 				testCheckupName,
-				&config.Config{Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
+				&config.Config{UID: testCheckupUID, Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
 			)
 
 			assert.ErrorContains(t, testCheckup.Setup(), expectedErr)
@@ -161,7 +163,7 @@ func TestTeardownInTargetNamespaceShouldSucceed(t *testing.T) {
 		testClient,
 		testTargetNs,
 		testCheckupName,
-		&config.Config{Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
+		&config.Config{UID: testCheckupUID, Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
 	)
 
 	assert.NoError(t, testCheckup.Setup())
@@ -212,7 +214,7 @@ func TestTeardownInTargetNamespaceShouldFailWhen(t *testing.T) {
 				testClient,
 				testTargetNs,
 				testCheckupName,
-				&config.Config{Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
+				&config.Config{UID: testCheckupUID, Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
 			)
 
 			assert.NoError(t, testCheckup.Setup())
@@ -254,7 +256,13 @@ func TestCheckupRunShouldCreateAJob(t *testing.T) {
 				testClient,
 				testTargetNs,
 				testCheckupName,
-				&config.Config{Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName, EnvVars: testCase.envVars},
+				&config.Config{
+					UID:                testCheckupUID,
+					Image:              testImage,
+					Timeout:            testTimeout,
+					ServiceAccountName: testServiceAccountName,
+					EnvVars:            testCase.envVars,
+				},
 			)
 
 			checkupJobName := checkup.NameJob(testCheckupName)
@@ -266,6 +274,7 @@ func TestCheckupRunShouldCreateAJob(t *testing.T) {
 
 			expectedResultsConfigMapName := checkup.NameResultsConfigMap(testCheckupName)
 			expectedEnvVars := []corev1.EnvVar{
+				{Name: checkup.UIDEnvVarName, Value: testCheckupUID},
 				{Name: checkup.ResultsConfigMapNameEnvVarName, Value: expectedResultsConfigMapName},
 				{Name: checkup.ResultsConfigMapNameEnvVarNamespace, Value: testTargetNs},
 			}
@@ -308,7 +317,7 @@ func TestCheckupRunShouldSucceed(t *testing.T) {
 				testClient,
 				testTargetNs,
 				testCheckupName,
-				&config.Config{Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
+				&config.Config{UID: testCheckupUID, Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
 			)
 
 			checkupJobName := checkup.NameJob(testCheckupName)
@@ -349,7 +358,7 @@ func TestCheckupRunShouldFailWhen(t *testing.T) {
 			testClient,
 			testTargetNs,
 			testCheckupName,
-			&config.Config{Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
+			&config.Config{UID: testCheckupUID, Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
 		)
 
 		assert.NoError(t, testCheckup.Setup())
@@ -364,7 +373,7 @@ func TestCheckupRunShouldFailWhen(t *testing.T) {
 			testClient,
 			testTargetNs,
 			testCheckupName,
-			&config.Config{Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
+			&config.Config{UID: testCheckupUID, Image: testImage, Timeout: testTimeout, ServiceAccountName: testServiceAccountName},
 		)
 
 		assert.NoError(t, testCheckup.Setup())
@@ -380,7 +389,7 @@ func TestCheckupRunShouldFailWhen(t *testing.T) {
 			testClient,
 			testTargetNs,
 			testCheckupName,
-			&config.Config{Image: testImage, Timeout: time.Nanosecond, ServiceAccountName: testServiceAccountName},
+			&config.Config{UID: testCheckupUID, Image: testImage, Timeout: time.Nanosecond, ServiceAccountName: testServiceAccountName},
 		)
 
 		assert.NoError(t, testCheckup.Setup())
@@ -396,7 +405,7 @@ func TestCheckupRunShouldFailWhen(t *testing.T) {
 			testClient,
 			testTargetNs,
 			testCheckupName,
-			&config.Config{Image: testImage, Timeout: time.Second, ServiceAccountName: testServiceAccountName},
+			&config.Config{UID: testCheckupUID, Image: testImage, Timeout: time.Second, ServiceAccountName: testServiceAccountName},
 		)
 
 		checkupJobName := checkup.NameJob(testCheckupName)

--- a/kiagnose/internal/config/config.go
+++ b/kiagnose/internal/config/config.go
@@ -37,6 +37,7 @@ var (
 )
 
 type Config struct {
+	UID                string
 	Image              string
 	Timeout            time.Duration
 	ServiceAccountName string
@@ -64,6 +65,7 @@ func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMa
 	}
 
 	return &Config{
+		UID:                string(configMap.UID),
 		Image:              parser.Image,
 		Timeout:            parser.Timeout,
 		ServiceAccountName: parser.ServiceAccountName,

--- a/kiagnose/internal/config/config_test.go
+++ b/kiagnose/internal/config/config_test.go
@@ -38,6 +38,7 @@ import (
 const (
 	configMapNamespace = "target-ns"
 	configMapName      = "cm1"
+	configMapUID       = "0123456789"
 
 	imageName               = "registry:5000/echo-checkup:latest"
 	timeoutValue            = "1m"
@@ -64,6 +65,7 @@ func TestReadFromConfigMapShouldSucceed(t *testing.T) {
 				types.ServiceAccountNameKey: serviceAccountNameValue,
 			},
 			expectedConfig: &config.Config{
+				UID:                configMapUID,
 				Image:              imageName,
 				Timeout:            stringToDurationMustParse(timeoutValue),
 				ServiceAccountName: serviceAccountNameValue,
@@ -79,6 +81,7 @@ func TestReadFromConfigMapShouldSucceed(t *testing.T) {
 				types.ParamNameKeyPrefix + param2Key: param2Value,
 			},
 			expectedConfig: &config.Config{
+				UID:                configMapUID,
 				Image:              imageName,
 				Timeout:            stringToDurationMustParse(timeoutValue),
 				ServiceAccountName: serviceAccountNameValue,
@@ -211,6 +214,7 @@ func newConfigMap(namespace, name string, data map[string]string) *corev1.Config
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			UID:       configMapUID,
 		},
 		Data: data,
 	}


### PR DESCRIPTION
Currently, the source and target VMIs have a label `latency-check-vm` with a hard-coded empty string value.
This prevents execution of multiple instances of this checkup in parallel (for more details see issue #164).

1. Add a new `CHECKUP_UID` environment variable in the API between the framework and the checkup.
2. Change the label name to "latency-check/uid" to better reflect its value.
3. Add the checkup's UID as the value of the "latency-check/uid" label.

To get checkup's UID:
```bash
kubectl get cm -n <target-namespace> <cm-name> -o jsonpath='{.metadata.uid}'
```

To list VMI objects by checkup's UID:
```bash
kubectl get vmis -n <target-namespace> -l latency-check-vm=<checkup-UID>
```

~~Depends on PR #169.~~
Replaces PR #171.