### PR TITLE
checkup, Collect logs

### DIFF
--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -122,9 +122,11 @@ func (c *Checkup) Run() error {
 		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
 
-	if c.job, err = job.WaitForJobToFinish(c.client, c.job, c.jobTimeout); err != nil {
+	var updatedJob *batchv1.Job
+	if updatedJob, err = job.WaitForJobToFinish(c.client, c.job, c.jobTimeout); err != nil {
 		return fmt.Errorf("%s: %v", errPrefix, err)
 	}
+	c.job = updatedJob
 
 	return nil
 }

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -22,6 +22,7 @@ package checkup
 import (
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -133,6 +134,20 @@ func (c *Checkup) Run() error {
 
 func (c *Checkup) Results() (results.Results, error) {
 	return results.ReadFromConfigMap(c.client, c.resultConfigMap.Namespace, c.resultConfigMap.Name)
+}
+
+func (c *Checkup) Logs() error {
+	if c.job == nil {
+		return fmt.Errorf("job is nil")
+	}
+
+	var err error
+	var logs string
+	if logs, err = job.GetLogs(c.client, c.job); err != nil {
+		return err
+	}
+	log.Printf("checkup job %q Logs:\n%s\n", c.job.Name, logs)
+	return nil
 }
 
 func (c *Checkup) SetTeardownTimeout(duration time.Duration) {

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -369,7 +369,7 @@ func TestCheckupRunShouldFailWhen(t *testing.T) {
 
 		assert.NoError(t, testCheckup.Setup())
 		assert.ErrorContains(t, testCheckup.Run(), "initial RV \"\" is not supported")
-		assert.NoError(t, testCheckup.Teardown())
+		assert.ErrorContains(t, testCheckup.Teardown(), "initial RV \"\" is not supported")
 	})
 
 	t.Run("Job wont finish on time", func(t *testing.T) {
@@ -385,6 +385,7 @@ func TestCheckupRunShouldFailWhen(t *testing.T) {
 
 		assert.NoError(t, testCheckup.Setup())
 		assert.ErrorContains(t, testCheckup.Run(), wait.ErrWaitTimeout.Error())
+		testClient.injectWatchWithJobDeleteEvent(testCheckupName)
 		assert.NoError(t, testCheckup.Teardown())
 	})
 
@@ -405,6 +406,7 @@ func TestCheckupRunShouldFailWhen(t *testing.T) {
 
 		assert.NoError(t, testCheckup.Setup())
 		assert.ErrorContains(t, testCheckup.Run(), wait.ErrWaitTimeout.Error())
+		testClient.injectWatchWithJobDeleteEvent(testCheckupName)
 		assert.NoError(t, testCheckup.Teardown())
 	})
 }

--- a/kiagnose/internal/checkup/checkup_test.go
+++ b/kiagnose/internal/checkup/checkup_test.go
@@ -171,7 +171,7 @@ func TestTeardownInTargetNamespaceShouldSucceed(t *testing.T) {
 	testClient.injectJobWatchEvent(newJobWithCondition(checkupJobName, completeTrueJobCondition))
 	assert.NoError(t, testCheckup.Run())
 
-	testClient.injectWatchWithJobDeleteEvent(testTargetNs, checkupJobName)
+	testClient.injectWatchWithJobDeleteEvent(checkupJobName)
 	assert.NoError(t, testCheckup.Teardown())
 
 	assertNamespaceExists(t, testClient.Clientset, testTargetNs)
@@ -279,7 +279,7 @@ func TestCheckupRunShouldCreateAJob(t *testing.T) {
 			actualJob.ResourceVersion = ""
 			assert.Equal(t, actualJob, expectedJob)
 
-			testClient.injectWatchWithJobDeleteEvent(testTargetNs, checkupJobName)
+			testClient.injectWatchWithJobDeleteEvent(checkupJobName)
 			assert.NoError(t, testCheckup.Teardown())
 		})
 	}
@@ -317,7 +317,7 @@ func TestCheckupRunShouldSucceed(t *testing.T) {
 			assert.NoError(t, testCheckup.Setup())
 			assert.NoError(t, testCheckup.Run())
 
-			testClient.injectWatchWithJobDeleteEvent(testTargetNs, checkupJobName)
+			testClient.injectWatchWithJobDeleteEvent(checkupJobName)
 			assert.NoError(t, testCheckup.Teardown())
 		})
 	}
@@ -510,13 +510,13 @@ func (c *testsClient) injectJobWatchEvent(job *batchv1.Job) {
 	c.PrependWatchReactor(jobResource, watchReactionFn)
 }
 
-func (c *testsClient) injectWatchWithJobDeleteEvent(namespace, name string) {
+func (c *testsClient) injectWatchWithJobDeleteEvent(name string) {
 	watchReactionFn := func(action clienttesting.Action) (bool, watch.Interface, error) {
 		watcher := watch.NewRaceFreeFake()
 		watcher.Delete(&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            name,
-				Namespace:       namespace,
+				Namespace:       testTargetNs,
 				ResourceVersion: "123",
 			},
 		})

--- a/kiagnose/internal/launcher/launcher.go
+++ b/kiagnose/internal/launcher/launcher.go
@@ -21,6 +21,7 @@ package launcher
 
 import (
 	"errors"
+	"log"
 	"strings"
 	"time"
 
@@ -32,6 +33,7 @@ type workload interface {
 	Setup() error
 	Run() error
 	Results() (results.Results, error)
+	Logs() error
 	Teardown() error
 }
 
@@ -81,6 +83,10 @@ func (l Launcher) Run() (runErr error) {
 	}
 
 	defer func() {
+		if err := l.checkup.Logs(); err != nil {
+			log.Printf("failed to collect logs: %v", err)
+		}
+
 		if err := l.checkup.Teardown(); err != nil {
 			errorPool = append(errorPool, err)
 		}

--- a/kiagnose/internal/launcher/launcher_test.go
+++ b/kiagnose/internal/launcher/launcher_test.go
@@ -256,6 +256,10 @@ func (s checkupStub) Results() (results.Results, error) {
 	return s.results, nil
 }
 
+func (s checkupStub) Logs() error {
+	return nil
+}
+
 func (s checkupStub) Teardown() error {
 	return s.failTeardown
 }

--- a/manifests/kiagnose.yaml
+++ b/manifests/kiagnose.yaml
@@ -41,6 +41,14 @@ rules:
       - create
       - delete
       - watch
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs:
+      - list
+  - apiGroups: [ "" ]
+    resources: [ "pods/log" ]
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Currently checkup job's logs are not collected by kiagnose. 
This PR collects the checkup's logs and print them in kiagnose's logs in order to make them more visible for de facto debugging.