### PR TITLE
Introduce python based e2e tests

### DIFF
--- a/.github/workflows/checkup-echo.check.yaml
+++ b/.github/workflows/checkup-echo.check.yaml
@@ -42,3 +42,28 @@ jobs:
         run: ./checkups/echo/automation/make.sh --e2e -- --run-tests
       - name: Delete cluster
         run: ./automation/make.sh --e2e -- --delete-cluster
+  e2e-test-py:
+    name: e2e-py
+    runs-on: ubuntu-latest
+    env:
+      CRI: docker
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Build kiagnose image
+        run: ./automation/make.sh --build-core --build-core-image
+      - name: Build checkup image
+        working-directory: ./checkups/echo
+        run: ./automation/make.sh --build-checkup-image
+      - name: Start cluster
+        run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-cluster
+      - name: Deploy kiagnose
+        run: ./automation/make.sh --e2e -- --load-kiagnose-image
+      - name: Deploy Echo checkup
+        run: ./checkups/echo/automation/make.sh --e2e -- --deploy-checkup
+      - name: Build test image
+        run: ./automation/e2e.sh --build-test-image
+      - name: Run e2e tests
+        run: ./checkups/echo/automation/make.sh --e2e -- --run-tests-py
+      - name: Delete cluster
+        run: ./automation/make.sh --e2e -- --delete-cluster

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,45 @@
+# End to End Tests
+
+This is the home of the Kiagnose E2E tests.
+
+## Content
+- Infrastructure specification: [Container image specification](./infra/Dockerfile).
+  A container based workspace on which the E2E can be executed.
+- Test library helpers: [libtest](./libtest).
+- Tests, separated by subjects in folders and files.
+
+## Testing Framework
+
+The tests are based on the [pytest](https://pytest.org/) testing python
+framework.
+
+## Development Environment
+
+The tests are running in a containerized environment.
+For local development, the infra image needs to be built.
+
+### Build Image
+In order to build the image, one can use podman:
+`podman build -f ./Dockerfile -t kiagnose-e2e-test .`
+
+### Running the Tests
+To run the tests, just execute:
+`podman run -ti --rm --net=host -v $(pwd):/workspace/kiagnose:Z -v ${HOME}/.kube:/root/.kube:ro,Z kiagnose-e2e-test`
+
+> **Note**: The tests run on the host network namespace, where access to the k8s cluster is available.
+> The `kubeconfig` configuration is shared through a volume to the container.
+
+> **Note**: The default command execution runs all test.
+
+### Running format & lint
+The format and lint are processing only the python based test code.
+
+- Format:
+  `podman run -ti --rm -v $(pwd):/workspace/kiagnose:Z kiagnose-e2e-test black -S --check --diff ./test`
+- Lint:
+  `podman run -ti --rm -v $(pwd):/workspace/kiagnose:Z kiagnose-e2e-test python3 -m flake8 --max-line-length 100 ./test`
+
+
+### Accessing the container (for debugging)
+To access the shell in order to run individual commands, execute:
+`podman run -ti --rm -v $(pwd):/workspace/kiagnose:Z kiagnose-e2e-test bash`

--- a/test/README.md
+++ b/test/README.md
@@ -23,7 +23,22 @@ In order to build the image, one can use podman:
 `podman build -f ./Dockerfile -t kiagnose-e2e-test .`
 
 ### Running the Tests
+The tests are expecting a running k8s cluster and a valid kubeconfig that allows
+clients to access the cluster.
+
+A common flow includes the following steps before running the tests:
+- Build items under test:
+  `./automation/make.sh --build-core --build-core-image --e2e --create-cluster --load-kiagnose-image`
+
+  Similar, individual checkups should build and load their images to the kind cluster
+  before running their relevant tests.
+- Build test runner image:
+  `./automation/e2e.sh --build-test-image`
+
 To run the tests, just execute:
+`./checkups/echo/automation/e2e.sh --run-tests-py`
+
+or directly:
 `podman run -ti --rm --net=host -v $(pwd):/workspace/kiagnose:Z -v ${HOME}/.kube:/root/.kube:ro,Z kiagnose-e2e-test`
 
 > **Note**: The tests run on the host network namespace, where access to the k8s cluster is available.

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -1,0 +1,80 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+
+from ocp_resources.resource import get_client
+from ocp_resources.namespace import Namespace
+from ocp_resources.service_account import ServiceAccount
+from ocp_resources.cluster_role import ClusterRole
+from ocp_resources.cluster_role_binding import ClusterRoleBinding
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def kclient():
+    return get_client()
+
+
+@pytest.fixture(scope="session")
+def kiagnose_cluster_role(kclient) -> ClusterRole:
+    cluster_role = ClusterRole(
+        name="kiagnose",
+        client=kclient,
+        api_groups=[""],
+        permissions_to_resources=["configmaps"],
+        verbs=["get", "list", "create", "delete", "update", "patch"],
+    )
+    cluster_role.add_rule(
+        api_groups=["rbac.authorization.k8s.io"],
+        permissions_to_resources=["roles", "rolebindings"],
+        verbs=["get", "list", "create", "delete"],
+    )
+    cluster_role.add_rule(
+        api_groups=["batch"],
+        permissions_to_resources=["jobs"],
+        verbs=["get", "list", "create", "delete", "watch"],
+    )
+
+    with cluster_role as cr:
+        yield cr
+
+
+@pytest.fixture(scope="session")
+def kiagnose_namespace(kclient) -> Namespace:
+    with Namespace("kiagnose", client=kclient) as ns:
+        yield ns
+
+
+@pytest.fixture(scope="session")
+def kiagnose_deployment(kclient, kiagnose_namespace, kiagnose_cluster_role) -> dict:
+    with ServiceAccount("kiagnose", kiagnose_namespace.name, client=kclient) as sa:
+        with ClusterRoleBinding(
+            name="kiagnose",
+            cluster_role=kiagnose_cluster_role.name,
+            subjects=[
+                {
+                    "kind": "ServiceAccount",
+                    "name": sa.name,
+                    "namespace": kiagnose_namespace.name,
+                },
+            ],
+        ) as crb:
+            yield {
+                "namespace": kiagnose_namespace,
+                "serviceaccount": sa,
+                "clusterrole": kiagnose_cluster_role,
+                "clusterrolebinding": crb,
+            }

--- a/test/e2e/echo/__init__.py
+++ b/test/e2e/echo/__init__.py
@@ -1,0 +1,15 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.

--- a/test/e2e/echo/conftest.py
+++ b/test/e2e/echo/conftest.py
@@ -1,0 +1,36 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+
+import pytest
+
+from ocp_resources.namespace import Namespace
+from ocp_resources.service_account import ServiceAccount
+
+
+TARGET_NAMESPACE = "checkup-e2e-test"
+TARGET_SERVICE_ACCOUNT = "checkup-e2e-test"
+
+
+@pytest.fixture
+def target_ns(kclient) -> Namespace:
+    with Namespace(TARGET_NAMESPACE, client=kclient) as ns:
+        yield ns
+
+
+@pytest.fixture
+def target_sa(kclient, target_ns) -> ServiceAccount:
+    with ServiceAccount(TARGET_SERVICE_ACCOUNT, target_ns.name, client=kclient) as sa:
+        yield sa

--- a/test/e2e/echo/echo_test.py
+++ b/test/e2e/echo/echo_test.py
@@ -1,0 +1,48 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+
+from ocp_resources.configmap import ConfigMap
+
+from . import kiagnose
+
+
+def test_successful_echo(kclient, kiagnose_deployment, target_ns, target_sa):
+    with ConfigMap(
+        name="echo-checkup-test",
+        namespace=target_ns.name,
+        data={
+            "spec.image": kiagnose.CHECKUP_IMAGE,
+            "spec.timeout": "1m",
+            "spec.serviceAccountName": target_sa.name,
+            "spec.param.message": "Hi!",
+        },
+        client=kclient,
+    ) as cm:
+        with kiagnose.job(
+            kclient,
+            kiagnose_deployment["namespace"].name,
+            kiagnose_deployment["serviceaccount"].name,
+            cm,
+        ) as j:
+            j.wait_for_condition(
+                condition=j.Condition.COMPLETE,
+                status=j.Condition.Status.TRUE,
+                timeout=30,
+            )
+
+            data = cm.instance.data
+            assert "true" == data.get("status.succeeded")
+            assert "Hi!" == data.get("status.result.echo")

--- a/test/e2e/echo/kiagnose.py
+++ b/test/e2e/echo/kiagnose.py
@@ -1,0 +1,56 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+
+import os
+
+from ocp_resources.configmap import ConfigMap
+from ocp_resources.job import Job
+from openshift.dynamic import DynamicClient
+
+FRAMEWORK_IMAGE = os.getenv("KIAGNOSE_IMAGE", "quay.io/kiagnose/kiagnose:devel")
+CHECKUP_IMAGE = os.getenv("CHECKUP_IMAGE", "quay.io/kiagnose/echo-checkup:devel")
+
+ENV_CONFIGMAP_NAMESPACE_KEY = "CONFIGMAP_NAMESPACE"
+ENV_CONFIGMAP_NAME_KEY = "CONFIGMAP_NAME"
+
+
+def job(
+    client: DynamicClient, namespace: str, service_account: str, configmap: ConfigMap
+) -> Job:
+    return Job(
+        name="test-checkup",
+        namespace=namespace,
+        client=client,
+        backoff_limit=0,
+        service_account=service_account,
+        restart_policy="Never",
+        containers=[
+            {
+                "name": "framework",
+                "image": FRAMEWORK_IMAGE,
+                "env": [
+                    {
+                        "name": ENV_CONFIGMAP_NAMESPACE_KEY,
+                        "value": configmap.namespace,
+                    },
+                    {
+                        "name": ENV_CONFIGMAP_NAME_KEY,
+                        "value": configmap.name,
+                    },
+                ],
+            }
+        ],
+    )

--- a/test/infra/Dockerfile
+++ b/test/infra/Dockerfile
@@ -1,0 +1,15 @@
+FROM quay.io/centos/centos:stream9
+
+COPY requirements.txt /
+
+RUN \
+    dnf -y install \
+      python3-pip \
+    && \
+    dnf clean all \
+    && \
+    python3 -m pip install -r requirements.txt
+
+WORKDIR /workspace/kiagnose
+
+CMD ["pytest"]

--- a/test/infra/requirements.txt
+++ b/test/infra/requirements.txt
@@ -1,0 +1,30 @@
+# Base: centos:stream9
+
+# pytest
+attrs==22.1.0
+iniconfig==1.1.1
+packaging==21.3
+pluggy==1.0.0
+py==1.11.0
+pyparsing==3.0.9
+pytest==7.1.3
+tomli==2.0.1
+
+# linters
+## flake8
+flake8==5.0.4
+mccabe==0.7.0
+pycodestyle==2.9.1
+pyflakes==2.5.0
+
+## black (formatter)
+black==22.8.0
+click==8.1.3
+mypy-extensions==0.4.3
+pathspec==0.10.1
+platformdirs==2.5.2
+typing-extensions==4.3.0
+tomli==2.0.1
+
+# Kubernetes/Openshift client
+openshift-python-wrapper==4.12.1


### PR DESCRIPTION
Introduce an E2E test suite, based on the pytest testing framework.

The tests mimics the existing `echo` checkup e2e test which is implemented in a `bash` script.

Following changes are planned to:
- Remove the `bash` e2e tests.
- Introduce a vm-latency checkup e2e test instead of the `bash` one.
- Push the test-image to the registry and auto-build it per need (when the Dockerfile or the requirements.txt files change).