### PR TITLE
dockerfile: Bump the ubi-minimal base image

### DIFF
--- a/checkups/echo/Dockerfile
+++ b/checkups/echo/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-751.1655117800
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941
 
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" &&\
     chmod 744 kubectl &&\

--- a/checkups/kubevirt-vm-latency/Dockerfile
+++ b/checkups/kubevirt-vm-latency/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-751.1655117800
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941
 
 COPY ./bin/kubevirt-vm-latency /usr/bin
 

--- a/dockerfiles/Dockerfile.kiagnose
+++ b/dockerfiles/Dockerfile.kiagnose
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-751.1655117800
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941
 
 COPY ./bin/kiagnose /usr/bin
 


### PR DESCRIPTION
Keep the base image up to date to avoid security vulnerabilities.