### PR TITLE
Deploy Kiagnose to a target namespace

### DIFF
--- a/README.install.md
+++ b/README.install.md
@@ -1,6 +1,6 @@
 # Kiagnose Installation
 
-In order to install Kiagnose on your cluster:
+In order to install Kiagnose on your namespace:
 
 1. Clone this repository:
 
@@ -8,25 +8,24 @@ In order to install Kiagnose on your cluster:
 git clone https://github.com/kiagnose/kiagnose.git
 ```
 
-2. Apply the following manifest from the project root directory (as a `cluster-admin` user):
+2. Apply the following manifest from the project root directory to the desired target namespace:
 
 ```bash
-kubectl apply -f ./manifests/kiagnose.yaml
+kubectl apply -f ./manifests/kiagnose.yaml -n <target-namespace>
 ```
 
 This manifest contains the following objects:
 
-- `kiagnose` [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) object.
 - `kiagnose` [ServiceAccount](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#service-account-permissions)
   object.
-- `kiagnose` [ClusterRole](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole)
-  and [ClusterRoleBinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding)
+- `kiagnose` [Role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole)
+  and [RoleBinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding)
   objects.
 
 # Kiagnose Removal
 
-1. Delete the objects contained in the following manifest from the project root directory (as a `cluster-admin` user):
+1. Delete the objects contained in the following manifest from the project root directory:
 
 ```bash
-kubectl delete -f ./manifests/kiagnose.yaml
+kubectl delete -f ./manifests/kiagnose.yaml  -n <target-namespace>
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Kiagnose passes user-supplied configuration to the checkup, and reports the chec
 ## Prerequisites
 In order to use Kiagnose you should have:
 1. A running Kubernetes cluster.
-2. Admin privileges on this cluster.
+2. Namespace-Admin privileges on this cluster.
 3. [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) utility.
 
 ## Kiagnose Installation
@@ -63,12 +63,14 @@ The user can configure the following under the `data` field:
 
 Example configuration:
 
+> **_NOTE:_** `metadata.namespace` field is optional.
+
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: example-checkup-config
-  namespace: <target namespace>
+  namespace: <target-namespace>
 data:
   spec.image: my-registry/example-checkup:main
   spec.timeout: 5m
@@ -90,6 +92,8 @@ The Kiagnose Job acts as a "short-lived" controller, and controls the checkup li
 
 Apply a Kiagnose Job using the following manifest file:
 
+> **_NOTE:_** `metadata.namespace` field is optional.
+
 > **_NOTE:_** The `CONFIGMAP_NAMESPACE` and `CONFIGMAP_NAME` environment variables should point to the previously applied ConfigMap object.
  
 ```yaml
@@ -97,7 +101,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: example-checkup
-  namespace: kiagnose
+  namespace: <target-namespace>
 spec:
   backoffLimit: 0
   template:
@@ -110,7 +114,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: CONFIGMAP_NAMESPACE
-              value: <target namespace>
+              value: <target-namespace>
             - name: CONFIGMAP_NAME
               value: example-checkup-config
 ```
@@ -156,12 +160,12 @@ data:
 
 In order to read the Kiagnose's logs (during or after its execution):
 ```bash
-kubectl logs job.batch/<Kiagnose-job-name> -n kiagnose
+kubectl logs job.batch/<Kiagnose-job-name> -n <target-namespace>
 ```
 
 Remove the Kiagnose Job and the ConfigMap object when the logs and the results are no longer needed:
 ```bash
-kubectl delete job.batch/<Kiagnose-job-name> -n kiagnose
+kubectl delete job.batch/<Kiagnose-job-name> -n <target-namespace>
 kubectl delete configmap <ConfigMap name> -n <target-namespace>
 ```
 

--- a/automation/e2e.sh
+++ b/automation/e2e.sh
@@ -151,7 +151,6 @@ fi
 
 if [ -n "${OPT_DEPLOY_KIAGNOSE}" ]; then
   ${KIND} load docker-image "${FRAMEWORK_IMAGE}" --name "${CLUSTER_NAME}"
-  ${KUBECTL} apply -f manifests/kiagnose.yaml
 fi
 
 if [ -n "${OPT_DELETE_CLUSTER}" ]; then

--- a/checkups/echo/README.md
+++ b/checkups/echo/README.md
@@ -11,13 +11,12 @@ This is an example checkup, used as a reference for creating more realistic chec
 
 The checkup requires only a ServiceAccount:
 ```bash
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -n <target-namespace> -f -
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: echo-checkup-sa
-  namespace: <target-namespace>
 EOF
 ```
 
@@ -27,12 +26,11 @@ In the user-supplied `ConfigMap` object, specify an arbitrary string as the valu
 
 In order to configure the checkup:
 ```bash
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -n <target-namespace> -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: echo-checkup-config
-  namespace: <target-namespace>
 data:
   spec.image: quay.io/kiagnose/echo-checkup:main
   spec.timeout: 1m
@@ -47,12 +45,11 @@ In order to execute the checkup:
 
 1. Apply the Kiagnose job:
 ```bash
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -n <target-namespace> -f -
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: echo-checkup1
-  namespace: kiagnose
 spec:
   backoffLimit: 0
   template:
@@ -73,7 +70,7 @@ EOF
 
 2. Wait for the Kiagnose Job to finish:
 ```bash
-kubectl wait --for=condition=complete --timeout=70s job/echo-checkup1 -n kiagnose
+kubectl wait --for=condition=complete --timeout=70s job/echo-checkup1 -n <target-namespace>
 ```
 
 ### Results Retrieval
@@ -121,7 +118,7 @@ metadata:
 
 Remove the Kiagnose Job and the ConfigMap object when the logs and the results are no longer needed:
 ```bash
-kubectl delete job.batch/echo-checkup1 -n kiagnose
+kubectl delete job.batch/echo-checkup1 -n <target-namespace>
 kubectl delete configmap echo-checkup-config -n <target-namespace>
 ```
 

--- a/checkups/kubevirt-vm-latency/README.md
+++ b/checkups/kubevirt-vm-latency/README.md
@@ -31,19 +31,17 @@ The default binding method is `bridge`.
 ## Permissions
 The checkup requires some additional permissions in order to operate:
 ```bash
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply -n <target-namespace> -f -
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: vm-latency-checkup-sa
-  namespace: <target-namespace>
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kubevirt-vm-latency-checker
-  namespace: <target-namespace>
 rules:
 - apiGroups: ["kubevirt.io"]
   resources: ["virtualmachineinstances"]
@@ -59,7 +57,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kubevirt-vm-latency-checker
-  namespace: <target-namespace>
 subjects:
 - kind: ServiceAccount
   name: vm-latency-checkup-sa
@@ -91,14 +88,13 @@ The checkup is configured by the following parameters:
 > Specifying both `source_node` and `target_node` will override this behaviour and each VM will be created on the desired node.
 
 ### Example
-```yaml
-cat <<EOF | kubectl apply -f -
+```bash
+cat <<EOF | kubectl apply -n <target-namespace> -f -
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubevirt-vm-latency-checkup-config
-  namespace: <target-namespace>
 data:
   spec.image: quay.io/kiagnose/kubevirt-vm-latency:main
   spec.timeout: 5m
@@ -114,14 +110,13 @@ EOF
 
 ## How to run
 The checkup can be executed with a Batch Job: 
-```yaml
-cat <<EOF | kubectl apply -f -
+```bash
+cat <<EOF | kubectl apply -n <target-namespace> -f -
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: kubevirt-vm-latency-checkup
-  namespace: kiagnose
 spec:
   backoffLimit: 0
   template:
@@ -144,7 +139,7 @@ EOF
 
 Wait for the checkup to finish:
 ```bash
-kubectl wait job kubevirt-vm-latency-checkup -n kiagnose --for condition=complete --timeout 6m
+kubectl wait job kubevirt-vm-latency-checkup -n <target-namespace> --for condition=complete --timeout 6m
 ```
 
 ## Results
@@ -216,7 +211,7 @@ status.failureReason: "run: failed to run check: failed due to connectivity issu
 
 ## Clean up
 ```bash
-kubectl delete job -n kiagnose kubevirt-vm-latency-checkup
+kubectl delete job -n <target-namespace> kubevirt-vm-latency-checkup
 kubectl delete config-map -n <target-namespace> kubevirt-vm-latency-checkup-config
 ```
 Once the checkup is finished it's safe to remove the ClusterRole:

--- a/kiagnose/internal/checkup/checkup.go
+++ b/kiagnose/internal/checkup/checkup.go
@@ -259,7 +259,7 @@ func NameResultsConfigMapWriterRole(checkupName string) string {
 }
 
 func NameJob(checkupName string) string {
-	return checkupName
+	return checkupName + "-checkup"
 }
 
 func concentrateErrors(errs []error) error {

--- a/manifests/kiagnose.yaml
+++ b/manifests/kiagnose.yaml
@@ -1,17 +1,11 @@
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: kiagnose
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kiagnose
-  namespace: kiagnose
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: kiagnose
 rules:
@@ -51,15 +45,14 @@ rules:
       - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: kiagnose
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: kiagnose
 subjects:
   - kind: ServiceAccount
     name: kiagnose
-    namespace: kiagnose
 ...


### PR DESCRIPTION
In order to make checkups executable by a namespace admin, in a target namespace, while keeping the kiagnose API, 
move the kiagnose Job and RBAC objects to the target namespace.

Signed-off-by: Orel Misan <omisan@redhat.com>