### PR TITLE
checkups, vm-latency: Drop unused preflight step

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -65,10 +65,6 @@ func New(c vmi.KubevirtVmisClient, uid, namespace string, params config.CheckupP
 	}
 }
 
-func (c *checkup) Preflight() error {
-	return nil
-}
-
 const (
 	SourceVmiName        = "latency-check-source"
 	TargetVmiName        = "latency-check-target"

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
@@ -53,7 +53,6 @@ func TestCheckupSetupShouldFailWhen(t *testing.T) {
 		testClient.failGetNetAttachDef = expectedError
 		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, newTestsCheckupParameters(), &checkerStub{})
 
-		assert.NoError(t, testCheckup.Preflight())
 		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedError.Error())
 	})
 
@@ -64,7 +63,6 @@ func TestCheckupSetupShouldFailWhen(t *testing.T) {
 		testClient.returnNetAttachDef = &netattdefv1.NetworkAttachmentDefinition{}
 		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, newTestsCheckupParameters(), &checkerStub{})
 
-		assert.NoError(t, testCheckup.Preflight())
 		assert.ErrorContains(t, testCheckup.Setup(context.Background()), expectedError.Error())
 	})
 
@@ -78,7 +76,6 @@ func TestCheckupSetupShouldFailWhen(t *testing.T) {
 		testCtx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		assert.NoError(t, testCheckup.Preflight())
 		assert.ErrorContains(t, testCheckup.Setup(testCtx), expectedError.Error())
 	})
 }
@@ -92,7 +89,6 @@ func TestCheckupTeardownShouldFailWhen(t *testing.T) {
 		testCtx, cancel := context.WithTimeout(context.Background(), testTimeout)
 		defer cancel()
 
-		assert.NoError(t, testCheckup.Preflight())
 		assert.NoError(t, testCheckup.Setup(testCtx))
 
 		expectedErr := errors.New("delete vmi test error")
@@ -106,7 +102,6 @@ func TestCheckupTeardownShouldFailWhen(t *testing.T) {
 		testClient.returnNetAttachDef = &netattdefv1.NetworkAttachmentDefinition{}
 		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, newTestsCheckupParameters(), &checkerStub{})
 
-		assert.NoError(t, testCheckup.Preflight())
 		assert.NoError(t, testCheckup.Setup(context.Background()))
 
 		testCtx, cancel := context.WithTimeout(context.Background(), testTimeout)
@@ -145,7 +140,6 @@ func TestCheckupSetupShouldCreateVMsWith(t *testing.T) {
 			testClient.returnNetAttachDef = testCase.netAttachDef
 			testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, newTestsCheckupParameters(), &checkerStub{})
 
-			assert.NoError(t, testCheckup.Preflight())
 			assert.NoError(t, testCheckup.Setup(context.Background()))
 			assert.Len(t, testClient.createdVmis, 2)
 			for _, createVMI := range testClient.createdVmis {
@@ -162,7 +156,6 @@ func TestCheckupSetupShouldCreateVMsWithPodAntiAffinity(t *testing.T) {
 		testClient.returnNetAttachDef = newTestNetAttachDef("")
 		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, config.CheckupParameters{}, &checkerStub{})
 
-		assert.NoError(t, testCheckup.Preflight())
 		assert.NoError(t, testCheckup.Setup(context.Background()))
 		assertVmiPodAntiAffinityExist(t, testClient, checkup.SourceVmiName)
 		assertVmiPodAntiAffinityExist(t, testClient, checkup.TargetVmiName)
@@ -182,7 +175,6 @@ func TestCheckupSetupShouldCreateVMsWithNodeAffinity(t *testing.T) {
 		testCheckupParams := config.CheckupParameters{SourceNodeName: testSourceNode, TargetNodeName: testTargetNode}
 		testCheckup := checkup.New(testClient, testCheckupUID, testNamespace, testCheckupParams, &checkerStub{})
 
-		assert.NoError(t, testCheckup.Preflight())
 		assert.NoError(t, testCheckup.Setup(context.Background()))
 		assertVmiNodeAffinityExist(t, testClient, checkup.SourceVmiName, testSourceNode)
 		assertVmiNodeAffinityExist(t, testClient, checkup.TargetVmiName, testTargetNode)

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher.go
@@ -28,7 +28,6 @@ import (
 )
 
 type checkup interface {
-	Preflight() error
 	Setup(ctx context.Context) error
 	Run() error
 	Teardown(ctx context.Context) error
@@ -61,11 +60,6 @@ func (l launcher) Run() (runErr error) {
 		}
 		runErr = failureReason(runStatus)
 	}()
-
-	if err := l.checkup.Preflight(); err != nil {
-		runStatus.FailureReason = append(runStatus.FailureReason, err.Error())
-		return err
-	}
 
 	if err := l.checkup.Setup(context.Background()); err != nil {
 		runStatus.FailureReason = append(runStatus.FailureReason, err.Error())

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -83,21 +83,6 @@ func TestLauncherShould(t *testing.T) {
 		assert.ErrorContains(t, testLauncher.Run(), errorReport.Error())
 	})
 
-	t.Run("fail when preflight is failing", func(t *testing.T) {
-		testLauncher := launcher.New(checkupStub{failPreflight: errorPreflight}, reporterStub{})
-		assert.ErrorContains(t, testLauncher.Run(), errorPreflight.Error())
-	})
-
-	t.Run("fail when preflight and report are failing", func(t *testing.T) {
-		testLauncher := launcher.New(
-			checkupStub{failPreflight: errorPreflight},
-			reporterStub{failReport: errorReport},
-		)
-		err := testLauncher.Run()
-		assert.ErrorContains(t, err, errorPreflight.Error())
-		assert.ErrorContains(t, err, errorReport.Error())
-	})
-
 	t.Run("fail when setup is failing", func(t *testing.T) {
 		testLauncher := launcher.New(checkupStub{failSetup: errorSetup}, reporterStub{})
 		assert.ErrorContains(t, testLauncher.Run(), errorSetup.Error())
@@ -183,22 +168,16 @@ func TestLauncherShouldSuccessfullyProduceStatusResults(t *testing.T) {
 }
 
 var (
-	errorPreflight = errors.New("preflight check error")
-	errorSetup     = errors.New("setup error")
-	errorRun       = errors.New("run error")
-	errorTeardown  = errors.New("teardown error")
-	errorReport    = errors.New("report error")
+	errorSetup    = errors.New("setup error")
+	errorRun      = errors.New("run error")
+	errorTeardown = errors.New("teardown error")
+	errorReport   = errors.New("report error")
 )
 
 type checkupStub struct {
-	failPreflight error
-	failSetup     error
-	failRun       error
-	failTeardown  error
-}
-
-func (s checkupStub) Preflight() error {
-	return s.failPreflight
+	failSetup    error
+	failRun      error
+	failTeardown error
 }
 
 func (s checkupStub) Setup(_ context.Context) error {


### PR DESCRIPTION
The preflight step, in which some validation was planned to be executed, is not being used.

One of the main reasons has to do with the realization that the validations would have required elevated permissions in the cluster/NS. Moreover, such checks may just be raceful due to the K8s operation mode (e.g. the existence of an entity may say nothing about its actual state 1msec later).

Therefore, this step is removed from the checkup.