### PR TITLE
GitHub actions: Run checks on release branches

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -2,9 +2,13 @@ name: checks
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release-**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release-**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/checkup-echo.check.yaml
+++ b/.github/workflows/checkup-echo.check.yaml
@@ -2,9 +2,13 @@ name: checkup-echo.checks
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release-**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release-**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -2,9 +2,13 @@ name: checkup-kubevirt-vm-latency.checks
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release-**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release-**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Currently, our GitHub actions checks workflows (unit tests and e2e), are triggered only on `push` or `pull_request` to the main branch. They are not triggered on stable release branches.

Add a trigger to check workflows on `push` or `pull_request` to release branches, in order to support back-porting as well.

Signed-off-by: Orel Misan <omisan@redhat.com>