### PR TITLE
vmlatency: Add securityContext to checkup's container

### DIFF
--- a/checkups/kubevirt-vm-latency/README.md
+++ b/checkups/kubevirt-vm-latency/README.md
@@ -142,6 +142,14 @@ spec:
       containers:
         - name: vm-latency-checkup
           image: quay.io/kiagnose/kubevirt-vm-latency:main
+          securityContext:
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            seccompProfile:
+              type: "RuntimeDefault"
           env:
             - name: CONFIGMAP_NAMESPACE
               value: <target-namespace>

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -254,6 +254,14 @@ spec:
       containers:
         - name: vm-latency-checkup
           image: ${CHECKUP_IMAGE}
+          securityContext:
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            seccompProfile:
+              type: "RuntimeDefault"
           env:
             - name: CONFIGMAP_NAMESPACE
               value: ${TARGET_NAMESPACE}

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -249,10 +249,10 @@ spec:
   backoffLimit: 0
   template:
     spec:
-      serviceAccount: ${VM_LATENCY_SERVICE_ACCOUNT_NAME}
+      serviceAccountName: ${VM_LATENCY_SERVICE_ACCOUNT_NAME}
       restartPolicy: Never
       containers:
-        - name: framework
+        - name: vm-latency-checkup
           image: ${CHECKUP_IMAGE}
           env:
             - name: CONFIGMAP_NAMESPACE


### PR DESCRIPTION
Currently, when executing this checkup on DS, the following warning message appears:
```
Warning: would violate PodSecurity "restricted:latest":
allowPrivilegeEscalation != false (container "vm-latency-checkup"
must set securityContext.allowPrivilegeEscalation=false),
unrestricted capabilities
(container "vm-latency-checkup" must set securityContext.capabilities.drop=["ALL"]),
runAsNonRoot != true
(pod or container "vm-latency-checkup" must set securityContext.runAsNonRoot=true),
seccompProfile
(pod or container "vm-latency-checkup" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```
Add a [securityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core) to the checkup's container.

Signed-off-by: Orel Misan <omisan@redhat.com>