### PR TITLE
vmlatency, Dockerfile: Upgrade base image version

### DIFF
--- a/checkups/kubevirt-vm-latency/Dockerfile
+++ b/checkups/kubevirt-vm-latency/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-994
 
 COPY ./bin/kubevirt-vm-latency /usr/bin
 


### PR DESCRIPTION
In order to address security issues discovered in the base image, upgrade it to version `8.6-994`.

Signed-off-by: Orel Misan <omisan@redhat.com>