### PR TITLE
Introduce python based e2e tests

### DIFF
--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -107,3 +107,29 @@ jobs:
         run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --run-tests
       - name: Delete cluster
         run: ./automation/make.sh --e2e -- --delete-cluster
+  e2e-test-py:
+    name: e2e-py
+    runs-on: ubuntu-latest
+    env:
+      CRI: docker
+      KUBEVIRT_USE_EMULATION: true
+    steps:
+      - name: Unload the br_netfilter kernel module to remove traffic restriction between bridge ports
+        run:  sudo rmmod br_netfilter
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Build checkup image
+        working-directory: ./checkups/kubevirt-vm-latency
+        run: ./automation/make.sh --build-checkup --build-checkup-image
+      - name: Start cluster
+        run: ./automation/make.sh --e2e -- --install-kind --install-kubectl --create-multi-node-cluster
+      - name: Deploy kubevirt, CNAO and the NetworkAttachementDefinition
+        run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --deploy-kubevirt --deploy-cnao --define-nad
+      - name: Deploy VM latency checkup
+        run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --deploy-checkup
+      - name: Build test image
+        run: ./automation/e2e.sh --build-test-image
+      - name: Run e2e tests
+        run: ./checkups/kubevirt-vm-latency/automation/make.sh --e2e -- --run-tests-py
+      - name: Delete cluster
+        run: ./automation/make.sh --e2e -- --delete-cluster

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,50 @@
+# End to End Tests
+
+This is the home of the Kiagnose E2E tests.
+
+## Content
+- Infrastructure specification: [Container image specification](./infra/Dockerfile).
+  A container based workspace on which the E2E can be executed.
+- Test library helpers: [libtest](./libtest).
+- Tests, separated by subjects in folders and files.
+
+## Testing Framework
+
+The tests are based on the [pytest](https://pytest.org/) testing framework.
+
+## Development Environment
+
+The tests are running in a containerized environment.
+For local development, the infra image needs to be built.
+
+### Build Image
+In order to build the image, one can use podman:
+
+`podman build -f ./Dockerfile -t kiagnose-e2e-test .`
+
+### Running the Tests
+
+> **Note**: The tests run on the host network namespace, where access to the k8s cluster is available.
+> The `kubeconfig` configuration is shared through a volume to the container.
+
+> **Note**: The default command execution runs all test.
+
+To run the tests, just execute:
+
+`podman run -ti --rm --net=host -v $(pwd):/workspace/kiagnose:Z -v ${HOME}/.kube:/root/.kube:ro,Z kiagnose-e2e-test`
+
+### Running format & lint
+The format and lint are processing only the python based test code.
+
+- Format:
+
+  `podman run -ti --rm -v $(pwd):/workspace/kiagnose:Z kiagnose-e2e-test black -S --check --diff ./test`
+- Lint:
+
+  `podman run -ti --rm -v $(pwd):/workspace/kiagnose:Z kiagnose-e2e-test python3 -m flake8 --max-line-length 100 ./test`
+
+
+### Accessing the container (for debugging)
+To access the shell in order to run individual commands, execute:
+
+`podman run -ti --rm -v $(pwd):/workspace/kiagnose:Z kiagnose-e2e-test bash`

--- a/test/README.md
+++ b/test/README.md
@@ -23,11 +23,32 @@ In order to build the image, one can use podman:
 `podman build -f ./Dockerfile -t kiagnose-e2e-test .`
 
 ### Running the Tests
+The tests are expecting a running k8s cluster and a valid kubeconfig that allows
+clients to access the cluster.
+
+A common flow includes the following steps before running the tests:
+- Prepare the cluster under test:
+
+  `./automation/make.sh --e2e --create-cluster`
+
+  Similar, individual checkups should build and load their images to the kind cluster
+  before running their relevant tests.
+- Build test runner image:
+
+  `./automation/e2e.sh --build-test-image`
 
 > **Note**: The tests run on the host network namespace, where access to the k8s cluster is available.
 > The `kubeconfig` configuration is shared through a volume to the container.
 
 > **Note**: The default command execution runs all test.
+
+To run the tests, just execute:
+
+`./checkups/kubevirt-vm-latency/automation/e2e.sh --run-tests-py`
+
+or directly:
+
+`podman run -ti --rm --net=host -v $(pwd):/workspace/kiagnose:Z -v ${HOME}/.kube:/root/.kube:ro,Z kiagnose-e2e-test`
 
 To run the tests, just execute:
 

--- a/test/e2e/__init__.py
+++ b/test/e2e/__init__.py
@@ -1,0 +1,15 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -1,0 +1,39 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+
+import pytest
+
+from ocp_resources.resource import get_client
+
+from .role import Role
+
+
+@pytest.fixture(scope="session")
+def kclient():
+    return get_client()
+
+
+@pytest.fixture(scope="session")
+def checkup_configmap_role(kclient, project_ns) -> Role:
+    with Role(
+        client=kclient,
+        name="checkup-configmap-access",
+        namespace=project_ns.name,
+        rules=[
+            {"apiGroups": [""], "resources": ["configmaps"], "verbs": ["get", "update"]}
+        ],
+    ) as r:
+        yield r

--- a/test/e2e/role.py
+++ b/test/e2e/role.py
@@ -1,0 +1,45 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+
+from ocp_resources.role import Role as baseRole
+
+
+class Role(baseRole):
+    def __init__(self, client, name, namespace, rules=(), **kwargs):
+        super().__init__(client=client, name=name, namespace=namespace, **kwargs)
+        self.rules = list(rules)
+
+    def to_dict(self):
+        self.res = super().to_dict()
+        if self.yaml_file:
+            return self.res
+
+        if self.rules:
+            self._set_rules()
+
+        return self.res
+
+    def add_rule(self, api_groups, resources, verbs):
+        self.rules.append(
+            {
+                "apiGroups": api_groups,
+                "resources": resources,
+                "verbs": verbs,
+            }
+        )
+
+    def _set_rules(self):
+        self.res["rules"] = self.rules

--- a/test/e2e/vmlatency/__init__.py
+++ b/test/e2e/vmlatency/__init__.py
@@ -1,0 +1,15 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.

--- a/test/e2e/vmlatency/conftest.py
+++ b/test/e2e/vmlatency/conftest.py
@@ -1,0 +1,107 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+
+import os
+
+import pytest
+
+from ocp_resources.namespace import Namespace
+from ocp_resources.service_account import ServiceAccount
+from ocp_resources.role_binding import RoleBinding
+from ocp_resources.network_attachment_definition import NetworkAttachmentDefinition
+
+from ..role import Role
+
+VM_LATENCY_CHECKUP_NAME = "kubevirt-vm-latency-checkup"
+
+PROJECT_NAMESPACE = "target-ns"
+CHECKUP_SERVICE_ACCOUNT = "vm-latency-checkup"
+
+NET_ATTACH_DEF_NAME = os.getenv("NET_ATTACH_DEF_NAME", "bridge-network")
+
+
+@pytest.fixture(scope="session")
+def project_ns(kclient) -> Namespace:
+    return Namespace(PROJECT_NAMESPACE, client=kclient)
+
+
+@pytest.fixture(scope="session")
+def checkup_sa(kclient, project_ns) -> ServiceAccount:
+    with ServiceAccount(CHECKUP_SERVICE_ACCOUNT, project_ns.name, client=kclient) as sa:
+        yield sa
+
+
+@pytest.fixture(scope="session")
+def checkup_role(kclient, project_ns) -> Role:
+    role = Role(
+        client=kclient,
+        name=VM_LATENCY_CHECKUP_NAME,
+        namespace=project_ns.name,
+    )
+    role.add_rule(
+        api_groups=["kubevirt.io"],
+        resources=["virtualmachineinstances"],
+        verbs=["get", "create", "delete"],
+    )
+    role.add_rule(
+        api_groups=["subresources.kubevirt.io"],
+        resources=["virtualmachineinstances/console"],
+        verbs=["get"],
+    )
+    role.add_rule(
+        api_groups=["k8s.cni.cncf.io"],
+        resources=["network-attachment-definitions"],
+        verbs=["get"],
+    )
+
+    with role as r:
+        yield r
+
+
+@pytest.fixture(scope="session")
+def configmap_role_binding(kclient, checkup_configmap_role, checkup_sa) -> RoleBinding:
+    with RoleBinding(
+        name=checkup_configmap_role.name,
+        namespace=checkup_configmap_role.namespace,
+        client=kclient,
+        role_ref_kind="Role",
+        role_ref_name=checkup_configmap_role.name,
+        subjects_kind="ServiceAccount",
+        subjects_name=checkup_sa.name,
+    ) as rb:
+        yield rb
+
+
+@pytest.fixture(scope="session")
+def checkup_role_binding(kclient, checkup_role, checkup_sa) -> RoleBinding:
+    with RoleBinding(
+        name=VM_LATENCY_CHECKUP_NAME,
+        namespace=checkup_role.namespace,
+        client=kclient,
+        role_ref_kind="Role",
+        role_ref_name=checkup_role.name,
+        subjects_kind="ServiceAccount",
+        subjects_name=checkup_sa.name,
+    ) as rb:
+        yield rb
+
+
+@pytest.fixture(scope="session")
+def nad(project_ns) -> NetworkAttachmentDefinition:
+    return NetworkAttachmentDefinition(
+        name=NET_ATTACH_DEF_NAME,
+        namespace=project_ns.name,
+    )

--- a/test/e2e/vmlatency/job.py
+++ b/test/e2e/vmlatency/job.py
@@ -1,0 +1,71 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+
+import contextlib
+import os
+
+from ocp_resources.configmap import ConfigMap
+from ocp_resources.job import Job
+from ocp_resources.pod import Pod
+
+from openshift.dynamic import DynamicClient
+
+CHECKUP_IMAGE = os.getenv("CHECKUP_IMAGE", "quay.io/kiagnose/kubevirt-vm-latency:main")
+
+ENV_CONFIGMAP_NAMESPACE_KEY = "CONFIGMAP_NAMESPACE"
+ENV_CONFIGMAP_NAME_KEY = "CONFIGMAP_NAME"
+
+
+@contextlib.contextmanager
+def job(
+    client: DynamicClient, namespace: str, service_account: str, configmap: ConfigMap
+) -> Job:
+    with Job(
+        name="test-checkup",
+        namespace=namespace,
+        client=client,
+        backoff_limit=0,
+        service_account=service_account,
+        restart_policy="Never",
+        containers=[
+            {
+                "name": "vmlatency-checkup",
+                "image": CHECKUP_IMAGE,
+                "env": [
+                    {
+                        "name": ENV_CONFIGMAP_NAMESPACE_KEY,
+                        "value": configmap.namespace,
+                    },
+                    {
+                        "name": ENV_CONFIGMAP_NAME_KEY,
+                        "value": configmap.name,
+                    },
+                ],
+            }
+        ],
+    ) as j:
+        try:
+            yield j
+        finally:
+            print(j.instance)
+            print_logs(client, j)
+
+
+def print_logs(client: DynamicClient, j: Job):
+    pods = list(Pod.get(dyn_client=client, label_selector=f"job-name={j.name}"))
+    print(f"Checkup job pods: {[p.name for p in pods]}")
+    for pod in pods:
+        print(f"pod {pod.name} log:\n {pod.log()}")

--- a/test/e2e/vmlatency/vmi.py
+++ b/test/e2e/vmlatency/vmi.py
@@ -1,0 +1,36 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+
+import contextlib
+
+from ocp_resources.virtual_machine_instance import VirtualMachineInstance
+
+from openshift.dynamic import DynamicClient
+
+
+@contextlib.contextmanager
+def teardown_logging(client: DynamicClient):
+    try:
+        yield
+    except Exception:
+        vmis = list(VirtualMachineInstance.get(dyn_client=client))
+        print(f"Checkup VMI/s: {[v.name for v in vmis]}")
+        for vmi in vmis:
+            print(vmi.instance)
+            pod = vmi.virt_launcher_pod
+            print(pod.instance)
+            print(f"pod {pod.name} log:\n {pod.log(container='compute')}")
+        raise

--- a/test/e2e/vmlatency/vmlatency_test.py
+++ b/test/e2e/vmlatency/vmlatency_test.py
@@ -1,0 +1,69 @@
+# This file is part of the kiagnose project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2022 Red Hat, Inc.
+
+import contextlib
+
+from ocp_resources.configmap import ConfigMap
+from ocp_resources.resource import NamespacedResource
+
+from .job import job
+from . import vmi
+
+
+def test_successful_run(kclient, checkup_sa, checkup_role_binding, configmap_role_binding, nad):
+    namespace = checkup_sa.namespace
+    config_map = ConfigMap(
+        name="vmlatency-checkup-test",
+        namespace=namespace,
+        data={
+            "spec.timeout": "5m",
+            "spec.param.network_attachment_definition_namespace": nad.namespace,
+            "spec.param.network_attachment_definition_name": nad.name,
+            "spec.param.max_desired_latency_milliseconds": "500",
+            "spec.param.sample_duration_seconds": "5",
+        },
+        client=kclient,
+    )
+    with resource_dump(config_map) as cm:
+        with job(kclient, namespace, checkup_sa.name, cm) as j:
+            timeout = 480
+            attempts = 4
+            attempt_timeout = timeout / attempts
+            for attempt in range(attempts):
+                try:
+                    with vmi.teardown_logging(kclient):
+                        j.wait_for_condition(
+                            condition=j.Condition.COMPLETE,
+                            status=j.Condition.Status.TRUE,
+                            timeout=attempt_timeout,
+                        )
+                except Exception as e:
+                    print(f"failed on attempt {attempt}: {e}")
+                else:
+                    print(f"succeeded on attempt {attempt}")
+                    break
+
+        data = cm.instance.data
+        assert "true" == data.get("status.succeeded")
+
+
+@contextlib.contextmanager
+def resource_dump(resource: NamespacedResource) -> ConfigMap:
+    with resource as r:
+        try:
+            yield r
+        finally:
+            print(r.instance)

--- a/test/infra/Dockerfile
+++ b/test/infra/Dockerfile
@@ -1,0 +1,15 @@
+FROM quay.io/centos/centos:stream9
+
+COPY requirements.txt /
+
+RUN \
+    dnf -y install \
+      python3-pip \
+    && \
+    dnf clean all \
+    && \
+    python3 -m pip install -r requirements.txt
+
+WORKDIR /workspace/kiagnose
+
+CMD ["pytest"]

--- a/test/infra/requirements.txt
+++ b/test/infra/requirements.txt
@@ -1,0 +1,30 @@
+# Base: centos:stream9
+
+# pytest
+attrs==22.1.0
+iniconfig==1.1.1
+packaging==21.3
+pluggy==1.0.0
+py==1.11.0
+pyparsing==3.0.9
+pytest==7.1.3
+tomli==2.0.1
+
+# linters
+## flake8
+flake8==5.0.4
+mccabe==0.7.0
+pycodestyle==2.9.1
+pyflakes==2.5.0
+
+## black (formatter)
+black==22.8.0
+click==8.1.3
+mypy-extensions==0.4.3
+pathspec==0.10.1
+platformdirs==2.5.2
+typing-extensions==4.3.0
+tomli==2.0.1
+
+# Kubernetes/Openshift client
+openshift-python-wrapper==4.12.1


### PR DESCRIPTION
Introduce an E2E test suite, based on the pytest testing framework.

The tests mimics the existing `kubevirt-vm-latency` checkup e2e test which is implemented in a `bash` script.

Following changes are planned to include:
- Remove the `bash` e2e tests.
- Push the test-image to the registry and auto-build it per need (when the Dockerfile or the requirements.txt files change).