### PR TITLE
vmlatency: Randomize VMs MAC and IP addresses

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
@@ -21,6 +21,9 @@
 package vmi
 
 import (
+	"crypto/rand"
+	"net"
+
 	k8scorev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -205,6 +208,25 @@ func WithMacAddress(macAddress string) interfaceOption {
 	return func(iface *kvcorev1.Interface) {
 		iface.MacAddress = macAddress
 	}
+}
+
+// RandomMACAddress return random local unicast MAC address
+func RandomMACAddress() string {
+	const octetsCount = 6
+	address := make([]byte, octetsCount)
+	_, _ = rand.Read(address)
+	address[0] = 0x02
+	return net.HardwareAddr(address).String()
+}
+
+// RandomIPAddress return random private IPv4 CIDR notation address from range 10.0.0.0/8
+func RandomIPAddress() string {
+	const octetsCount = 4
+	address := make([]byte, octetsCount)
+	_, _ = rand.Read(address)
+	address[0] = 10
+	cidr := net.IPNet{IP: address, Mask: []byte{255, 0, 0, 0}}
+	return cidr.String()
 }
 
 func NewAlpine(name string, opts ...Option) *kvcorev1.VirtualMachineInstance {


### PR DESCRIPTION
Currently its not possible to run multiple instances of the checkup simultaneously, one of the reasons is due to hard-coded IP and MAC addresses.
VMs from one checkup instance conflict with VMs from  another checkup instance
and may cause false checkup results.

Randomize the MAC and IP addresses in order prevent such conflicts.

Fixes https://github.com/kiagnose/kiagnose/issues/164

Signed-off-by: Or Mergi <ormergi@redhat.com>