### PR TITLE
vmlatency, checkup: Add OwnerReference to VMIs

### DIFF
--- a/checkups/kubevirt-vm-latency/README.md
+++ b/checkups/kubevirt-vm-latency/README.md
@@ -155,6 +155,10 @@ spec:
               value: <target-namespace>
             - name: CONFIGMAP_NAME
               value: kubevirt-vm-latency-checkup-config
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
 EOF
 ```
 

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -271,6 +271,10 @@ spec:
               value: ${TARGET_NAMESPACE}
             - name: CONFIGMAP_NAME
               value: ${VM_LATENCY_CONFIGMAP}
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
 EOF
 
     ${KUBECTL} wait --for=condition=complete --timeout=10m job.batch/${CHECKUP_JOB} -n ${TARGET_NAMESPACE}

--- a/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/config.go
+++ b/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/config.go
@@ -37,6 +37,7 @@ var (
 type Config struct {
 	ConfigMapNamespace string
 	ConfigMapName      string
+	PodName            string
 	UID                string
 	Timeout            time.Duration
 	Params             map[string]string
@@ -63,6 +64,7 @@ func Read(client kubernetes.Interface, rawEnv map[string]string) (Config, error)
 	return Config{
 		ConfigMapNamespace: env.ConfigMapNamespace,
 		ConfigMapName:      env.ConfigMapName,
+		PodName:            env.PodName,
 		UID:                cmSettings.UID,
 		Timeout:            cmSettings.Timeout,
 		Params:             cmSettings.Params,

--- a/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/config.go
+++ b/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	ConfigMapNamespace string
 	ConfigMapName      string
 	PodName            string
+	PodUID             string
 	UID                string
 	Timeout            time.Duration
 	Params             map[string]string
@@ -65,6 +66,7 @@ func Read(client kubernetes.Interface, rawEnv map[string]string) (Config, error)
 		ConfigMapNamespace: env.ConfigMapNamespace,
 		ConfigMapName:      env.ConfigMapName,
 		PodName:            env.PodName,
+		PodUID:             env.PodUID,
 		UID:                cmSettings.UID,
 		Timeout:            cmSettings.Timeout,
 		Params:             cmSettings.Params,

--- a/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/environment.go
+++ b/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/environment.go
@@ -24,22 +24,26 @@ import "fmt"
 type environment struct {
 	ConfigMapNamespace string
 	ConfigMapName      string
+	PodName            string
 }
 
 const (
 	ConfigMapNamespaceEnvVarName = "CONFIGMAP_NAMESPACE"
 	ConfigMapNameEnvVarName      = "CONFIGMAP_NAME"
+	PodNameEnvVarName            = "HOSTNAME"
 )
 
 var (
 	ErrMissingConfigMapNamespace = fmt.Errorf("missing required environment variable: %q", ConfigMapNamespaceEnvVarName)
 	ErrMissingConfigMapName      = fmt.Errorf("missing required environment variable: %q", ConfigMapNameEnvVarName)
+	ErrMissingPodName            = fmt.Errorf("missing required environment variable: %q", PodNameEnvVarName)
 )
 
 func newEnvironment(rawEnv map[string]string) environment {
 	return environment{
 		ConfigMapNamespace: rawEnv[ConfigMapNamespaceEnvVarName],
 		ConfigMapName:      rawEnv[ConfigMapNameEnvVarName],
+		PodName:            rawEnv[PodNameEnvVarName],
 	}
 }
 
@@ -50,6 +54,10 @@ func (e environment) Validate() error {
 
 	if e.ConfigMapName == "" {
 		return ErrMissingConfigMapName
+	}
+
+	if e.PodName == "" {
+		return ErrMissingPodName
 	}
 
 	return nil

--- a/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/environment.go
+++ b/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/environment.go
@@ -25,12 +25,14 @@ type environment struct {
 	ConfigMapNamespace string
 	ConfigMapName      string
 	PodName            string
+	PodUID             string
 }
 
 const (
 	ConfigMapNamespaceEnvVarName = "CONFIGMAP_NAMESPACE"
 	ConfigMapNameEnvVarName      = "CONFIGMAP_NAME"
 	PodNameEnvVarName            = "HOSTNAME"
+	PodUIDEnvVarName             = "POD_UID"
 )
 
 var (
@@ -44,6 +46,7 @@ func newEnvironment(rawEnv map[string]string) environment {
 		ConfigMapNamespace: rawEnv[ConfigMapNamespaceEnvVarName],
 		ConfigMapName:      rawEnv[ConfigMapNameEnvVarName],
 		PodName:            rawEnv[PodNameEnvVarName],
+		PodUID:             rawEnv[PodUIDEnvVarName],
 	}
 }
 
@@ -59,6 +62,8 @@ func (e environment) Validate() error {
 	if e.PodName == "" {
 		return ErrMissingPodName
 	}
+
+	// PodUID field is optional, thus not validated
 
 	return nil
 }

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -89,8 +89,8 @@ func (c *checkup) Setup(ctx context.Context) error {
 	sourceVMIName := randomizeName(SourceVMINamePrefix)
 	targetVMIName := randomizeName(TargetVMINamePrefix)
 
-	sourceVmi := newLatencyCheckVmi(c.uid, sourceVMIName, c.params.SourceNodeName, netAttachDef)
-	targetVmi := newLatencyCheckVmi(c.uid, targetVMIName, c.params.TargetNodeName, netAttachDef)
+	sourceVmi := newLatencyCheckVmi(c.uid, sourceVMIName, c.params.SourceNodeName, c.params.PodName, c.params.PodUID, netAttachDef)
+	targetVmi := newLatencyCheckVmi(c.uid, targetVMIName, c.params.TargetNodeName, c.params.PodName, c.params.PodUID, netAttachDef)
 
 	if err = vmi.Start(c.client, c.namespace, sourceVmi); err != nil {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
@@ -115,7 +115,7 @@ func (c *checkup) Setup(ctx context.Context) error {
 }
 
 func newLatencyCheckVmi(
-	uid, name, nodeName string,
+	uid, name, nodeName, ownerName, ownerUID string,
 	netAttachDef *netattdefv1.NetworkAttachmentDefinition) *kvcorev1.VirtualMachineInstance {
 	const networkName = "net0"
 
@@ -129,6 +129,7 @@ func newLatencyCheckVmi(
 
 	macAddress := vmi.RandomMACAddress()
 	return vmi.NewAlpine(name,
+		vmi.WithOwnerReference(ownerName, ownerUID),
 		vmi.WithLabels(vmLabel),
 		vmi.WithAffinity(affinity),
 		vmi.WithMultusNetwork(networkName, netAttachDef.Namespace+"/"+netAttachDef.Name),

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
@@ -38,6 +38,8 @@ const (
 )
 
 type Config struct {
+	PodName                              string
+	PodUID                               string
 	NetworkAttachmentDefinitionName      string
 	NetworkAttachmentDefinitionNamespace string
 	TargetNodeName                       string
@@ -64,6 +66,8 @@ func New(baseConfig kconfig.Config) (Config, error) {
 	}
 
 	newConfig := Config{
+		PodName:                              baseConfig.PodName,
+		PodUID:                               baseConfig.PodUID,
 		NetworkAttachmentDefinitionName:      baseConfig.Params[NetworkNameParamName],
 		NetworkAttachmentDefinitionNamespace: baseConfig.Params[NetworkNamespaceParamName],
 		TargetNodeName:                       baseConfig.Params[TargetNodeNameParamName],

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
@@ -38,6 +38,8 @@ type configCreateTestCases struct {
 }
 
 const (
+	testPodName                       = "my-pod"
+	testPodUID                        = "0123456789-0123456789"
 	testNamespace                     = "default"
 	testNetAttachDefName              = "blue-net"
 	testDesiredMaxLatencyMilliseconds = 100
@@ -56,6 +58,8 @@ func TestCreateConfigFromParamsShould(t *testing.T) {
 				config.DesiredMaxLatencyMillisecondsParamName: fmt.Sprintf("%d", testDesiredMaxLatencyMilliseconds),
 			},
 			expectedConfig: config.Config{
+				PodName:                              testPodName,
+				PodUID:                               testPodUID,
 				SampleDurationSeconds:                config.DefaultSampleDurationSeconds,
 				NetworkAttachmentDefinitionName:      testNetAttachDefName,
 				NetworkAttachmentDefinitionNamespace: testNamespace,
@@ -70,6 +74,8 @@ func TestCreateConfigFromParamsShould(t *testing.T) {
 				config.SampleDurationSecondsParamName: fmt.Sprintf("%d", testSampleDurationSeconds),
 			},
 			expectedConfig: config.Config{
+				PodName:                              testPodName,
+				PodUID:                               testPodUID,
 				DesiredMaxLatencyMilliseconds:        config.DefaultDesiredMaxLatencyMilliseconds,
 				NetworkAttachmentDefinitionName:      testNetAttachDefName,
 				NetworkAttachmentDefinitionNamespace: testNamespace,
@@ -86,6 +92,8 @@ func TestCreateConfigFromParamsShould(t *testing.T) {
 				config.TargetNodeNameParamName:        testTargetNodeName,
 			},
 			expectedConfig: config.Config{
+				PodName:                              testPodName,
+				PodUID:                               testPodUID,
 				DesiredMaxLatencyMilliseconds:        config.DefaultDesiredMaxLatencyMilliseconds,
 				NetworkAttachmentDefinitionName:      testNetAttachDefName,
 				NetworkAttachmentDefinitionNamespace: testNamespace,
@@ -98,7 +106,11 @@ func TestCreateConfigFromParamsShould(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			baseConfig := kconfig.Config{Params: testCase.params}
+			baseConfig := kconfig.Config{
+				PodName: testPodName,
+				PodUID:  testPodUID,
+				Params:  testCase.params,
+			}
 			testConfig, err := config.New(baseConfig)
 			assert.NoError(t, err)
 			assert.Equal(t, testConfig, testCase.expectedConfig)

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/spec.go
@@ -26,6 +26,8 @@ import (
 
 	k8scorev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kvcorev1 "kubevirt.io/api/core/v1"
@@ -57,6 +59,19 @@ func newBaseVmi(name string, opts ...Option) *kvcorev1.VirtualMachineInstance {
 	}
 
 	return vmi
+}
+
+func WithOwnerReference(ownerName, ownerUID string) Option {
+	return func(vmi *kvcorev1.VirtualMachineInstance) {
+		if ownerUID != "" && ownerName != "" {
+			vmi.ObjectMeta.OwnerReferences = append(vmi.ObjectMeta.OwnerReferences, k8smetav1.OwnerReference{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Name:       ownerName,
+				UID:        types.UID(ownerUID),
+			})
+		}
+	}
 }
 
 // withTerminationGracePeriodSecond sets TerminationGracePeriodSecond.

--- a/kiagnose/config/config.go
+++ b/kiagnose/config/config.go
@@ -37,6 +37,7 @@ var (
 type Config struct {
 	ConfigMapNamespace string
 	ConfigMapName      string
+	PodName            string
 	UID                string
 	Timeout            time.Duration
 	Params             map[string]string
@@ -63,6 +64,7 @@ func Read(client kubernetes.Interface, rawEnv map[string]string) (Config, error)
 	return Config{
 		ConfigMapNamespace: env.ConfigMapNamespace,
 		ConfigMapName:      env.ConfigMapName,
+		PodName:            env.PodName,
 		UID:                cmSettings.UID,
 		Timeout:            cmSettings.Timeout,
 		Params:             cmSettings.Params,

--- a/kiagnose/config/config.go
+++ b/kiagnose/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	ConfigMapNamespace string
 	ConfigMapName      string
 	PodName            string
+	PodUID             string
 	UID                string
 	Timeout            time.Duration
 	Params             map[string]string
@@ -65,6 +66,7 @@ func Read(client kubernetes.Interface, rawEnv map[string]string) (Config, error)
 		ConfigMapNamespace: env.ConfigMapNamespace,
 		ConfigMapName:      env.ConfigMapName,
 		PodName:            env.PodName,
+		PodUID:             env.PodUID,
 		UID:                cmSettings.UID,
 		Timeout:            cmSettings.Timeout,
 		Params:             cmSettings.Params,

--- a/kiagnose/config/config_test.go
+++ b/kiagnose/config/config_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 const (
+	podName            = "my-pod"
 	configMapNamespace = "target-ns"
 	configMapName      = "cm1"
 	configMapUID       = "0123456789"
@@ -48,6 +49,7 @@ const (
 var validRawEnv = map[string]string{
 	config.ConfigMapNamespaceEnvVarName: configMapNamespace,
 	config.ConfigMapNameEnvVarName:      configMapName,
+	config.PodNameEnvVarName:            podName,
 }
 
 func TestReadShouldSucceed(t *testing.T) {
@@ -68,6 +70,7 @@ func TestReadShouldSucceed(t *testing.T) {
 			expectedConfig: config.Config{
 				ConfigMapNamespace: configMapNamespace,
 				ConfigMapName:      configMapName,
+				PodName:            podName,
 				UID:                configMapUID,
 				Timeout:            stringToDurationMustParse(timeoutValue),
 				Params:             map[string]string{},
@@ -84,6 +87,7 @@ func TestReadShouldSucceed(t *testing.T) {
 			expectedConfig: config.Config{
 				ConfigMapNamespace: configMapNamespace,
 				ConfigMapName:      configMapName,
+				PodName:            podName,
 				UID:                configMapUID,
 				Timeout:            stringToDurationMustParse(timeoutValue),
 				Params: map[string]string{
@@ -128,6 +132,14 @@ func TestEnvironmentReadShouldFail(t *testing.T) {
 			description:   "when both ConfigMap's environment variables are missing",
 			rawEnv:        map[string]string{},
 			expectedError: config.ErrMissingConfigMapNamespace,
+		},
+		{
+			description: "when pod name environment variable is missing",
+			rawEnv: map[string]string{
+				config.ConfigMapNamespaceEnvVarName: configMapNamespace,
+				config.ConfigMapNameEnvVarName:      configMapName,
+			},
+			expectedError: config.ErrMissingPodName,
 		},
 	}
 

--- a/kiagnose/config/config_test.go
+++ b/kiagnose/config/config_test.go
@@ -35,6 +35,7 @@ import (
 
 const (
 	podName            = "my-pod"
+	podUID             = "0123456789-0123456789"
 	configMapNamespace = "target-ns"
 	configMapName      = "cm1"
 	configMapUID       = "0123456789"
@@ -50,6 +51,7 @@ var validRawEnv = map[string]string{
 	config.ConfigMapNamespaceEnvVarName: configMapNamespace,
 	config.ConfigMapNameEnvVarName:      configMapName,
 	config.PodNameEnvVarName:            podName,
+	config.PodUIDEnvVarName:             podUID,
 }
 
 func TestReadShouldSucceed(t *testing.T) {
@@ -71,6 +73,7 @@ func TestReadShouldSucceed(t *testing.T) {
 				ConfigMapNamespace: configMapNamespace,
 				ConfigMapName:      configMapName,
 				PodName:            podName,
+				PodUID:             podUID,
 				UID:                configMapUID,
 				Timeout:            stringToDurationMustParse(timeoutValue),
 				Params:             map[string]string{},
@@ -88,6 +91,7 @@ func TestReadShouldSucceed(t *testing.T) {
 				ConfigMapNamespace: configMapNamespace,
 				ConfigMapName:      configMapName,
 				PodName:            podName,
+				PodUID:             podUID,
 				UID:                configMapUID,
 				Timeout:            stringToDurationMustParse(timeoutValue),
 				Params: map[string]string{
@@ -151,6 +155,24 @@ func TestEnvironmentReadShouldFail(t *testing.T) {
 			assert.ErrorIs(t, err, testCase.expectedError)
 		})
 	}
+}
+
+func TestEnvironmentReadShouldSucceedWhenOptionalVarsAreMissing(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset(
+		newConfigMap(
+			configMapNamespace,
+			configMapName, map[string]string{types.TimeoutKey: timeoutValue},
+		),
+	)
+
+	t.Run("Pod UID is missing", func(t *testing.T) {
+		_, err := config.Read(fakeClient, map[string]string{
+			config.ConfigMapNamespaceEnvVarName: configMapNamespace,
+			config.ConfigMapNameEnvVarName:      configMapName,
+			config.PodNameEnvVarName:            podName,
+		})
+		assert.NoError(t, err)
+	})
 }
 
 func TestConfigMapReadShouldFail(t *testing.T) {

--- a/kiagnose/config/environment.go
+++ b/kiagnose/config/environment.go
@@ -24,22 +24,26 @@ import "fmt"
 type environment struct {
 	ConfigMapNamespace string
 	ConfigMapName      string
+	PodName            string
 }
 
 const (
 	ConfigMapNamespaceEnvVarName = "CONFIGMAP_NAMESPACE"
 	ConfigMapNameEnvVarName      = "CONFIGMAP_NAME"
+	PodNameEnvVarName            = "HOSTNAME"
 )
 
 var (
 	ErrMissingConfigMapNamespace = fmt.Errorf("missing required environment variable: %q", ConfigMapNamespaceEnvVarName)
 	ErrMissingConfigMapName      = fmt.Errorf("missing required environment variable: %q", ConfigMapNameEnvVarName)
+	ErrMissingPodName            = fmt.Errorf("missing required environment variable: %q", PodNameEnvVarName)
 )
 
 func newEnvironment(rawEnv map[string]string) environment {
 	return environment{
 		ConfigMapNamespace: rawEnv[ConfigMapNamespaceEnvVarName],
 		ConfigMapName:      rawEnv[ConfigMapNameEnvVarName],
+		PodName:            rawEnv[PodNameEnvVarName],
 	}
 }
 
@@ -50,6 +54,10 @@ func (e environment) Validate() error {
 
 	if e.ConfigMapName == "" {
 		return ErrMissingConfigMapName
+	}
+
+	if e.PodName == "" {
+		return ErrMissingPodName
 	}
 
 	return nil

--- a/kiagnose/config/environment.go
+++ b/kiagnose/config/environment.go
@@ -25,12 +25,14 @@ type environment struct {
 	ConfigMapNamespace string
 	ConfigMapName      string
 	PodName            string
+	PodUID             string
 }
 
 const (
 	ConfigMapNamespaceEnvVarName = "CONFIGMAP_NAMESPACE"
 	ConfigMapNameEnvVarName      = "CONFIGMAP_NAME"
 	PodNameEnvVarName            = "HOSTNAME"
+	PodUIDEnvVarName             = "POD_UID"
 )
 
 var (
@@ -44,6 +46,7 @@ func newEnvironment(rawEnv map[string]string) environment {
 		ConfigMapNamespace: rawEnv[ConfigMapNamespaceEnvVarName],
 		ConfigMapName:      rawEnv[ConfigMapNameEnvVarName],
 		PodName:            rawEnv[PodNameEnvVarName],
+		PodUID:             rawEnv[PodUIDEnvVarName],
 	}
 }
 
@@ -59,6 +62,8 @@ func (e environment) Validate() error {
 	if e.PodName == "" {
 		return ErrMissingPodName
 	}
+
+	// PodUID field is optional, thus not validated
 
 	return nil
 }


### PR DESCRIPTION
Currently, if a problem occurs during the teardown process, one or more VMIs could stay in the namespace as leftovers.

Add OwnerReference to source and target VMIs, in order to use the automatic K8s garbage collector, so they will be
garbage-collected when the checkup Pod is deleted.

The ownerReference is only created if the Pod's name and UID are known: The name should always be present, the UID is dependent on the user's configuration of downward API.

Signed-off-by: Orel Misan <omisan@redhat.com>