### PR TITLE
vmlatency: Define user at Dockerfile

### DIFF
--- a/checkups/kubevirt-vm-latency/Dockerfile
+++ b/checkups/kubevirt-vm-latency/Dockerfile
@@ -1,5 +1,12 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-994
 
+RUN microdnf install shadow-utils && \
+    adduser --system --no-create-home -u 1001 vm-latency && \
+    microdnf remove shadow-utils && \
+    microdnf clean all
+
 COPY ./bin/kubevirt-vm-latency /usr/bin
+
+USER 1001
 
 CMD kubevirt-vm-latency

--- a/checkups/kubevirt-vm-latency/README.md
+++ b/checkups/kubevirt-vm-latency/README.md
@@ -144,7 +144,6 @@ spec:
         - name: vm-latency-checkup
           image: quay.io/kiagnose/kubevirt-vm-latency:main
           securityContext:
-            runAsUser: 1000
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -260,7 +260,6 @@ spec:
         - name: vm-latency-checkup
           image: ${CHECKUP_IMAGE}
           securityContext:
-            runAsUser: 1000
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]


### PR DESCRIPTION
Currently, the vm latency Dockerfile does not specify the user running the kubevirt-vm-latency, thus it is implicitly running as root.

This required the checkup Job to specify the container's user.

Add a `USER` stanza to the vm latency checkup's Dockerfile.
Remove `runAsUser` from the container's securityContext.

Install `shadow-utils` in the image in order to use the `adduser` command, and remove it after creating the user.

Signed-off-by: Orel Misan <omisan@redhat.com>