### PR TITLE
config: Remove conversion to EnvVars and back

### DIFF
--- a/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/config.go
+++ b/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/config.go
@@ -21,10 +21,8 @@ package config
 
 import (
 	"errors"
-	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kiagnose/kiagnose/kiagnose/configmap"
@@ -39,7 +37,7 @@ var (
 type Config struct {
 	UID     string
 	Timeout time.Duration
-	EnvVars []corev1.EnvVar
+	Params  map[string]string
 }
 
 func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMapName string) (*Config, error) {
@@ -65,33 +63,11 @@ func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMa
 	return &Config{
 		UID:     string(configMap.UID),
 		Timeout: parser.Timeout,
-		EnvVars: paramsToEnvVars(parser.Params),
+		Params:  parser.Params,
 	}, nil
 }
 
 func isConfigMapAlreadyInUse(data map[string]string) bool {
 	_, exists := data[types.StartTimestampKey]
 	return exists
-}
-
-func paramsToEnvVars(params map[string]string) []corev1.EnvVar {
-	var envVars []corev1.EnvVar
-
-	for k, v := range params {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  strings.ToUpper(k),
-			Value: v,
-		})
-	}
-
-	return envVars
-}
-
-func EnvVarsToParams(envVars []corev1.EnvVar) map[string]string {
-	params := map[string]string{}
-	for _, v := range envVars {
-		params[v.Name] = v.Value
-	}
-
-	return params
 }

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
@@ -27,12 +27,12 @@ import (
 )
 
 const (
-	NetworkNamespaceParamName              = "NETWORK_ATTACHMENT_DEFINITION_NAMESPACE"
-	NetworkNameParamName                   = "NETWORK_ATTACHMENT_DEFINITION_NAME"
-	SampleDurationSecondsParamName         = "SAMPLE_DURATION_SECONDS"
-	SourceNodeNameParamName                = "SOURCE_NODE"
-	TargetNodeNameParamName                = "TARGET_NODE"
-	DesiredMaxLatencyMillisecondsParamName = "MAX_DESIRED_LATENCY_MILLISECONDS"
+	NetworkNamespaceParamName              = "network_attachment_definition_namespace"
+	NetworkNameParamName                   = "network_attachment_definition_name"
+	SampleDurationSecondsParamName         = "sample_duration_seconds"
+	SourceNodeNameParamName                = "source_node"
+	TargetNodeNameParamName                = "target_node"
+	DesiredMaxLatencyMillisecondsParamName = "max_desired_latency_milliseconds"
 )
 
 type Config struct {

--- a/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
@@ -46,7 +46,7 @@ func Run(env map[string]string, namespace string) error {
 		return err
 	}
 
-	cfg, err := config.New(kconfig.EnvVarsToParams(baseConfig.EnvVars))
+	cfg, err := config.New(baseConfig.Params)
 	if err != nil {
 		return err
 	}

--- a/kiagnose/config/config.go
+++ b/kiagnose/config/config.go
@@ -21,10 +21,8 @@ package config
 
 import (
 	"errors"
-	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kiagnose/kiagnose/kiagnose/configmap"
@@ -39,7 +37,7 @@ var (
 type Config struct {
 	UID     string
 	Timeout time.Duration
-	EnvVars []corev1.EnvVar
+	Params  map[string]string
 }
 
 func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMapName string) (*Config, error) {
@@ -65,33 +63,11 @@ func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMa
 	return &Config{
 		UID:     string(configMap.UID),
 		Timeout: parser.Timeout,
-		EnvVars: paramsToEnvVars(parser.Params),
+		Params:  parser.Params,
 	}, nil
 }
 
 func isConfigMapAlreadyInUse(data map[string]string) bool {
 	_, exists := data[types.StartTimestampKey]
 	return exists
-}
-
-func paramsToEnvVars(params map[string]string) []corev1.EnvVar {
-	var envVars []corev1.EnvVar
-
-	for k, v := range params {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  strings.ToUpper(k),
-			Value: v,
-		})
-	}
-
-	return envVars
-}
-
-func EnvVarsToParams(envVars []corev1.EnvVar) map[string]string {
-	params := map[string]string{}
-	for _, v := range envVars {
-		params[v.Name] = v.Value
-	}
-
-	return params
 }

--- a/kiagnose/config/config_test.go
+++ b/kiagnose/config/config_test.go
@@ -20,8 +20,6 @@
 package config_test
 
 import (
-	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -63,6 +61,7 @@ func TestReadFromConfigMapShouldSucceed(t *testing.T) {
 			expectedConfig: &config.Config{
 				UID:     configMapUID,
 				Timeout: stringToDurationMustParse(timeoutValue),
+				Params:  map[string]string{},
 			},
 		},
 		{
@@ -75,7 +74,10 @@ func TestReadFromConfigMapShouldSucceed(t *testing.T) {
 			expectedConfig: &config.Config{
 				UID:     configMapUID,
 				Timeout: stringToDurationMustParse(timeoutValue),
-				EnvVars: expectedEnvVars(param1Key, param1Value, param2Key, param2Value),
+				Params: map[string]string{
+					param1Key: param1Value,
+					param2Key: param2Value,
+				},
 			},
 		},
 	}
@@ -86,10 +88,6 @@ func TestReadFromConfigMapShouldSucceed(t *testing.T) {
 
 			actualConfig, err := config.ReadFromConfigMap(fakeClient, configMapNamespace, configMapName)
 			assert.NoError(t, err)
-
-			sort.Slice(actualConfig.EnvVars, func(i, j int) bool {
-				return actualConfig.EnvVars[i].Name < actualConfig.EnvVars[j].Name
-			})
 
 			assert.Equal(t, testCase.expectedConfig, actualConfig)
 		})
@@ -170,13 +168,6 @@ func newConfigMap(namespace, name string, data map[string]string) *corev1.Config
 			UID:       configMapUID,
 		},
 		Data: data,
-	}
-}
-
-func expectedEnvVars(param1Key, param1Value, param2Key, param2Value string) []corev1.EnvVar {
-	return []corev1.EnvVar{
-		{Name: strings.ToUpper(param1Key), Value: param1Value},
-		{Name: strings.ToUpper(param2Key), Value: param2Value},
 	}
 }
 


### PR DESCRIPTION
Since PR https://github.com/kiagnose/kiagnose/pull/189, the checkup receives its parameters
from the user-supplied ConfigMap instead from environment variables.

Currently, the read params are converted to type EnvVar, and then back to map[string]string.

Remove these redundant conversions.
Remove some dependencies as a side effect.

Note: This change breaks the current interface provided by the kiagnose library.

~~Depends on PR #219.~~

Signed-off-by: Orel Misan <omisan@redhat.com>