### PR TITLE
config: Change ReadFromConfigMap() returned value

### DIFF
--- a/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/config.go
+++ b/checkups/kubevirt-vm-latency/vendor/github.com/kiagnose/kiagnose/kiagnose/config/config.go
@@ -42,27 +42,27 @@ type Config struct {
 	EnvVars []corev1.EnvVar
 }
 
-func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMapName string) (*Config, error) {
+func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMapName string) (Config, error) {
 	configMap, err := configmap.Get(client, configMapNamespace, configMapName)
 	if err != nil {
-		return nil, err
+		return Config{}, err
 	}
 
 	if configMap.Data == nil {
-		return nil, ErrConfigMapDataIsNil
+		return Config{}, ErrConfigMapDataIsNil
 	}
 
 	if isConfigMapAlreadyInUse(configMap.Data) {
-		return nil, ErrConfigMapIsAlreadyInUse
+		return Config{}, ErrConfigMapIsAlreadyInUse
 	}
 
 	parser := newConfigMapParser(configMap.Data)
 	err = parser.Parse()
 	if err != nil {
-		return nil, err
+		return Config{}, err
 	}
 
-	return &Config{
+	return Config{
 		UID:     string(configMap.UID),
 		Timeout: parser.Timeout,
 		EnvVars: paramsToEnvVars(parser.Params),

--- a/kiagnose/config/config.go
+++ b/kiagnose/config/config.go
@@ -42,27 +42,27 @@ type Config struct {
 	EnvVars []corev1.EnvVar
 }
 
-func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMapName string) (*Config, error) {
+func ReadFromConfigMap(client kubernetes.Interface, configMapNamespace, configMapName string) (Config, error) {
 	configMap, err := configmap.Get(client, configMapNamespace, configMapName)
 	if err != nil {
-		return nil, err
+		return Config{}, err
 	}
 
 	if configMap.Data == nil {
-		return nil, ErrConfigMapDataIsNil
+		return Config{}, ErrConfigMapDataIsNil
 	}
 
 	if isConfigMapAlreadyInUse(configMap.Data) {
-		return nil, ErrConfigMapIsAlreadyInUse
+		return Config{}, ErrConfigMapIsAlreadyInUse
 	}
 
 	parser := newConfigMapParser(configMap.Data)
 	err = parser.Parse()
 	if err != nil {
-		return nil, err
+		return Config{}, err
 	}
 
-	return &Config{
+	return Config{
 		UID:     string(configMap.UID),
 		Timeout: parser.Timeout,
 		EnvVars: paramsToEnvVars(parser.Params),

--- a/kiagnose/config/config_test.go
+++ b/kiagnose/config/config_test.go
@@ -51,7 +51,7 @@ func TestReadFromConfigMapShouldSucceed(t *testing.T) {
 	type loadTestCase struct {
 		description    string
 		configMapData  map[string]string
-		expectedConfig *config.Config
+		expectedConfig config.Config
 	}
 
 	testCases := []loadTestCase{
@@ -60,7 +60,7 @@ func TestReadFromConfigMapShouldSucceed(t *testing.T) {
 			configMapData: map[string]string{
 				types.TimeoutKey: timeoutValue,
 			},
-			expectedConfig: &config.Config{
+			expectedConfig: config.Config{
 				UID:     configMapUID,
 				Timeout: stringToDurationMustParse(timeoutValue),
 			},
@@ -72,7 +72,7 @@ func TestReadFromConfigMapShouldSucceed(t *testing.T) {
 				types.ParamNameKeyPrefix + param1Key: param1Value,
 				types.ParamNameKeyPrefix + param2Key: param2Value,
 			},
-			expectedConfig: &config.Config{
+			expectedConfig: config.Config{
 				UID:     configMapUID,
 				Timeout: stringToDurationMustParse(timeoutValue),
 				EnvVars: expectedEnvVars(param1Key, param1Value, param2Key, param2Value),


### PR DESCRIPTION
Currently, the `ReadFromConfigMap()` function returns a pointer to `config.Config{}` struct.

This struct should be read-only, and has no mutating methods, so there is no need to return a pointer to it.

Note: This change breaks the API between the kiagnose library and the VM latency checkup.

Signed-off-by: Orel Misan <omisan@redhat.com>