### PR TITLE
vmlatency, config: Build checkup config from base config

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+
+	kconfig "github.com/kiagnose/kiagnose/kiagnose/config"
 )
 
 const (
@@ -56,21 +58,21 @@ const (
 	DefaultDesiredMaxLatencyMilliseconds = math.MaxInt
 )
 
-func New(params map[string]string) (Config, error) {
-	if len(params) == 0 {
+func New(baseConfig kconfig.Config) (Config, error) {
+	if len(baseConfig.Params) == 0 {
 		return Config{}, ErrInvalidParams
 	}
 
 	newConfig := Config{
-		NetworkAttachmentDefinitionName:      params[NetworkNameParamName],
-		NetworkAttachmentDefinitionNamespace: params[NetworkNamespaceParamName],
-		TargetNodeName:                       params[TargetNodeNameParamName],
-		SourceNodeName:                       params[SourceNodeNameParamName],
+		NetworkAttachmentDefinitionName:      baseConfig.Params[NetworkNameParamName],
+		NetworkAttachmentDefinitionNamespace: baseConfig.Params[NetworkNamespaceParamName],
+		TargetNodeName:                       baseConfig.Params[TargetNodeNameParamName],
+		SourceNodeName:                       baseConfig.Params[SourceNodeNameParamName],
 	}
 
 	var err error
 	sampleDuration := DefaultSampleDurationSeconds
-	if value, exists := params[SampleDurationSecondsParamName]; exists {
+	if value, exists := baseConfig.Params[SampleDurationSecondsParamName]; exists {
 		if sampleDuration, err = strconv.Atoi(value); err != nil {
 			return Config{}, fmt.Errorf("%q parameter is invalid: %v", SampleDurationSecondsParamName, err)
 		}
@@ -78,7 +80,7 @@ func New(params map[string]string) (Config, error) {
 	newConfig.SampleDurationSeconds = sampleDuration
 
 	desiredMaxLatency := DefaultDesiredMaxLatencyMilliseconds
-	if value, exists := params[DesiredMaxLatencyMillisecondsParamName]; exists {
+	if value, exists := baseConfig.Params[DesiredMaxLatencyMillisecondsParamName]; exists {
 		if desiredMaxLatency, err = strconv.Atoi(value); err != nil {
 			return Config{}, fmt.Errorf("%q parameter is invalid: %v", DesiredMaxLatencyMillisecondsParamName, err)
 		}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
@@ -26,6 +26,8 @@ import (
 
 	assert "github.com/stretchr/testify/require"
 
+	kconfig "github.com/kiagnose/kiagnose/kiagnose/config"
+
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/config"
 )
 
@@ -96,7 +98,8 @@ func TestCreateConfigFromParamsShould(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			testConfig, err := config.New(testCase.params)
+			baseConfig := kconfig.Config{Params: testCase.params}
+			testConfig, err := config.New(baseConfig)
 			assert.NoError(t, err)
 			assert.Equal(t, testConfig, testCase.expectedConfig)
 		})
@@ -124,7 +127,8 @@ func TestCreateConfigFromParamsShouldFailWhen(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			_, err := config.New(testCase.params)
+			baseConfig := kconfig.Config{Params: testCase.params}
+			_, err := config.New(baseConfig)
 			assert.Equal(t, err, testCase.expectedError)
 		})
 	}
@@ -150,7 +154,8 @@ func TestCreateConfigFromParamsShouldFailWhenMandatoryParamsAreMissing(t *testin
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			_, err := config.New(testCase.params)
+			baseConfig := kconfig.Config{Params: testCase.params}
+			_, err := config.New(baseConfig)
 			assert.Equal(t, err, testCase.expectedError)
 		})
 	}
@@ -177,7 +182,8 @@ func TestCreateConfigFromParamsShouldFailWhenMandatoryParamsAreInvalid(t *testin
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			_, err := config.New(testCase.params)
+			baseConfig := kconfig.Config{Params: testCase.params}
+			_, err := config.New(baseConfig)
 			assert.Equal(t, err, testCase.expectedError)
 		})
 	}
@@ -226,7 +232,8 @@ func TestCreateConfigFromParamsShouldFailWhenNodeNames(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			_, err := config.New(testCase.params)
+			baseConfig := kconfig.Config{Params: testCase.params}
+			_, err := config.New(baseConfig)
 			assert.Equal(t, err, testCase.expectedError)
 		})
 	}
@@ -255,7 +262,8 @@ func TestCreateConfigShouldFailWhenIntegerParamsAreInvalid(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			_, err := config.New(testCase.params)
+			baseConfig := kconfig.Config{Params: testCase.params}
+			_, err := config.New(baseConfig)
 			assert.ErrorContains(t, err, testCase.expectedError.Error())
 		})
 	}

--- a/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
@@ -46,7 +46,7 @@ func Run(env map[string]string, namespace string) error {
 		return err
 	}
 
-	cfg, err := config.New(baseConfig.Params)
+	cfg, err := config.New(baseConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently, the checkup's `config.Config{}` struct is built from a subset of the base config originating from the library's `config.Config{}` struct (its Params field).

Build the checkup's config from the base config in order to prepare for additional common fields which will originate from the kiagnose library.

Signed-off-by: Orel Misan <omisan@redhat.com>