### PR TITLE
vmlatency, main: Fix variable shadowing

### DIFF
--- a/checkups/kubevirt-vm-latency/cmd/main.go
+++ b/checkups/kubevirt-vm-latency/cmd/main.go
@@ -32,12 +32,13 @@ func main() {
 	const errMessagePrefix = "Kubevirt VM latency checkup failed"
 	env := environment.EnvToMap(os.Environ())
 
+	var err error
 	workingNamespace, err := environment.ReadNamespaceFile()
 	if err != nil {
 		log.Fatalf("%s: %v\n", errMessagePrefix, err)
 	}
 
-	if err := vmlatency.Run(env, workingNamespace); err != nil {
+	if err = vmlatency.Run(env, workingNamespace); err != nil {
 		log.Fatalf("%s: %v\n", errMessagePrefix, err)
 	}
 }


### PR DESCRIPTION
Currently, the second `err` variable is shadowing the first. Use a single `err` variable instead of two.

Signed-off-by: Orel Misan <omisan@redhat.com>