### PR TITLE
vmlatency, Dockerfile: Use Entrypoint instead of CMD

### DIFF
--- a/checkups/kubevirt-vm-latency/Dockerfile
+++ b/checkups/kubevirt-vm-latency/Dockerfile
@@ -9,4 +9,4 @@ COPY ./bin/kubevirt-vm-latency /usr/bin
 
 USER 1001
 
-CMD kubevirt-vm-latency
+ENTRYPOINT ["kubevirt-vm-latency"]


### PR DESCRIPTION
Currently, the Dockerfile is using the `CMD` stanza, which is supposed to provide defaults for an executing container [1].

Use the `ENTRYPOINT` stanza instead, which is used to configure a container that will run as an executable [2].

[1] https://docs.docker.com/engine/reference/builder/#cmd 
[2] https://docs.docker.com/engine/reference/builder/#entrypoint

Signed-off-by: Orel Misan <omisan@redhat.com>