### PR TITLE
vmlatency, config: Fix variable shadowing

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
@@ -91,7 +91,8 @@ func New(baseConfig kconfig.Config) (Config, error) {
 	}
 	newConfig.DesiredMaxLatencyMilliseconds = desiredMaxLatency
 
-	if err := newConfig.validate(); err != nil {
+	err = newConfig.validate()
+	if err != nil {
 		return Config{}, err
 	}
 


### PR DESCRIPTION
Currently, the `err` variable which holds the returned value from `newConfig.validate()` is shadowing a previous declaration.

Fix the variable shadowing.

Signed-off-by: Orel Misan <omisan@redhat.com>