### PR TITLE
vmlatency:  Align 'spec' and 'status' field names format 

### DIFF
--- a/checkups/kubevirt-vm-latency/README.md
+++ b/checkups/kubevirt-vm-latency/README.md
@@ -91,20 +91,20 @@ EOF
 ## Configuration
 The checkup is configured by the following parameters:
 
-| Name                                                                               | Description                                                                                                                  |
-|:-----------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------|
-| `timeout`                                                                          | Overall time the checkup can run.                                                                                            |
-| `network_attachment_definition_namespace`<br/>`network_attachment_definition_name` | `NetworkAttachmentDefinition` object on which <br/> the VMs are connected to and measure network latency.                    |
-| `sample_duration_seconds`                                                          | Network latency measurement sample time (optional).<br/> Default is 5 seconds.                                               |
-| `max_desired_latency_milliseconds`                                                 | Maximal network latency accepted, if the actual latency <br/> is higher the checkup will be considered as failed (optional). |
-| `source_node`<br/>`target_node`                                                    | Two ends of the network latency measurement (optional).<br/> When used, specifying both is mandatory.                        |
+| Name                                                                         | Description                                                                                                                  |
+|:-----------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------|
+| `timeout`                                                                    | Overall time the checkup can run.                                                                                            |
+| `networkAttachmentDefinitionNamespace`<br/>`networkAttachmentDefinitionName` | `NetworkAttachmentDefinition` object on which <br/> the VMs are connected to and measure network latency.                    |
+| `sampleDurationSeconds`                                                      | Network latency measurement sample time (optional).<br/> Default is 5 seconds.                                               |
+| `maxDesiredLatencyMilliseconds`                                              | Maximal network latency accepted, if the actual latency <br/> is higher the checkup will be considered as failed (optional). |
+| `sourceNode`<br/>`targetNode`                                                | Two ends of the network latency measurement (optional).<br/> When used, specifying both is mandatory.                        |
 
 > **_Note_**:
-> `timeout` should be greater than `sample_duration_seconds`.
+> `timeout` should be greater than `sampleDurationSeconds`.
 
 > **_Note_**:
 > By default the checkup source and target VMs will be created in a way they won't end up on the same cluster node.</br>
-> Specifying both `source_node` and `target_node` will override this behaviour and each VM will be created on the desired node.
+> Specifying both `sourceNode` and `targetNode` will override this behaviour and each VM will be created on the desired node.
 
 ### Example
 ```bash
@@ -116,12 +116,12 @@ metadata:
   name: kubevirt-vm-latency-checkup-config
 data:
   spec.timeout: 5m
-  spec.param.network_attachment_definition_namespace: "default"
-  spec.param.network_attachment_definition_name: "blue-network"
-  spec.param.max_desired_latency_milliseconds: "10"
-  spec.param.sample_duration_seconds: "5"
-  spec.param.source_node: "worker1"
-  spec.param.target_node: "worker2"
+  spec.param.networkAttachmentDefinitionNamespace: "default"
+  spec.param.networkAttachmentDefinitionName: "blue-network"
+  spec.param.maxDesiredLatencyMilliseconds: "10"
+  spec.param.sampleDurationSeconds: "5"
+  spec.param.sourceNode: "worker1"
+  spec.param.targetNode: "worker2"
 EOF
 ```
 
@@ -185,12 +185,12 @@ metadata:
   namespace: <target-namespace>
 data:
   spec.timeout: 5m
-  spec.param.network_attachment_definition_namespace: "default"
-  spec.param.network_attachment_definition_name: "blue-network"
-  spec.param.max_desired_latency_milliseconds: "10"
-  spec.param.sample_duration_seconds: "5"
-  spec.param.source_node: "worker1"
-  spec.param.target_node: "worker2"
+  spec.param.networkAttachmentDefinitionNamespace: "default"
+  spec.param.networkAttachmentDefinitionName: "blue-network"
+  spec.param.maxDesiredLatencyMilliseconds: "10"
+  spec.param.sampleDurationSeconds: "5"
+  spec.param.sourceNode: "worker1"
+  spec.param.targetNode: "worker2"
   status.succeeded: "true"
   status.failureReason: ""
   status.completionTimestamp: "2022-01-01T09:00:00Z"

--- a/checkups/kubevirt-vm-latency/automation/e2e.sh
+++ b/checkups/kubevirt-vm-latency/automation/e2e.sh
@@ -235,10 +235,10 @@ metadata:
   name: ${VM_LATENCY_CONFIGMAP}
 data:
   spec.timeout: 10m
-  spec.param.network_attachment_definition_namespace: "${TARGET_NAMESPACE}"
-  spec.param.network_attachment_definition_name: "bridge-network"
-  spec.param.max_desired_latency_milliseconds: "500"
-  spec.param.sample_duration_seconds: "5"
+  spec.param.networkAttachmentDefinitionNamespace: "${TARGET_NAMESPACE}"
+  spec.param.networkAttachmentDefinitionName: "bridge-network"
+  spec.param.maxDesiredLatencyMilliseconds: "500"
+  spec.param.sampleDurationSeconds: "5"
 EOF
 
     echo

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
@@ -103,7 +103,71 @@ func TestCreateConfigFromParamsShould(t *testing.T) {
 			},
 		},
 	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			baseConfig := kconfig.Config{
+				PodName: testPodName,
+				PodUID:  testPodUID,
+				Params:  testCase.params,
+			}
+			testConfig, err := config.New(baseConfig)
+			assert.NoError(t, err)
+			assert.Equal(t, testConfig, testCase.expectedConfig)
+		})
+	}
+}
 
+func TestCreateConfigShouldPreferNonDeprecatedParameters(t *testing.T) {
+	testCases := []configCreateTestCases{
+		{
+			description: "when both deprecated and non-deprecated params are specified",
+			params: map[string]string{
+				config.NetworkNameDeprecatedParamName:                   testNetAttachDefName + "999",
+				config.NetworkNamespaceDeprecatedParamName:              testNamespace + "999",
+				config.TargetNodeNameDeprecatedParamName:                testSourceNodeName + "999",
+				config.SourceNodeNameDeprecatedParamName:                testTargetNodeName + "999",
+				config.DesiredMaxLatencyMillisecondsDeprecatedParamName: fmt.Sprint(testDesiredMaxLatencyMilliseconds + 999),
+				config.SampleDurationSecondsDeprecatedParamName:         fmt.Sprint(testSampleDurationSeconds + 999),
+				config.NetworkNameParamName:                             testNetAttachDefName,
+				config.NetworkNamespaceParamName:                        testNamespace,
+				config.TargetNodeNameParamName:                          testSourceNodeName,
+				config.SourceNodeNameParamName:                          testTargetNodeName,
+				config.DesiredMaxLatencyMillisecondsParamName:           fmt.Sprint(testDesiredMaxLatencyMilliseconds),
+				config.SampleDurationSecondsParamName:                   fmt.Sprint(testSampleDurationSeconds),
+			},
+			expectedConfig: config.Config{
+				PodName:                              testPodName,
+				PodUID:                               testPodUID,
+				NetworkAttachmentDefinitionName:      testNetAttachDefName,
+				NetworkAttachmentDefinitionNamespace: testNamespace,
+				TargetNodeName:                       testSourceNodeName,
+				SourceNodeName:                       testTargetNodeName,
+				SampleDurationSeconds:                testSampleDurationSeconds,
+				DesiredMaxLatencyMilliseconds:        testDesiredMaxLatencyMilliseconds,
+			},
+		},
+		{
+			description: "fallback to deprecated parameters when new form is missing",
+			params: map[string]string{
+				config.NetworkNameDeprecatedParamName:                   testNetAttachDefName,
+				config.NetworkNamespaceDeprecatedParamName:              testNamespace,
+				config.TargetNodeNameDeprecatedParamName:                testSourceNodeName,
+				config.SourceNodeNameDeprecatedParamName:                testTargetNodeName,
+				config.DesiredMaxLatencyMillisecondsDeprecatedParamName: fmt.Sprint(testDesiredMaxLatencyMilliseconds),
+				config.SampleDurationSecondsDeprecatedParamName:         fmt.Sprint(testSampleDurationSeconds),
+			},
+			expectedConfig: config.Config{
+				PodName:                              testPodName,
+				PodUID:                               testPodUID,
+				NetworkAttachmentDefinitionName:      testNetAttachDefName,
+				NetworkAttachmentDefinitionNamespace: testNamespace,
+				TargetNodeName:                       testSourceNodeName,
+				SourceNodeName:                       testTargetNodeName,
+				SampleDurationSeconds:                testSampleDurationSeconds,
+				DesiredMaxLatencyMilliseconds:        testDesiredMaxLatencyMilliseconds,
+			},
+		},
+	}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
 			baseConfig := kconfig.Config{


### PR DESCRIPTION
Currently, the status fields and params fields are in different formats, params fields are snake case and the status fields are camel case.

Change the params fields to be aligned with status fields camel case format, its common format in k8s eco-system.

The current changes do not remove the old form parameters completely and they **can** be used.
The old form parameters should be removed when deprecated completely.