### PR TITLE
vmlatency, client: Add context to client layer

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -80,6 +80,7 @@ func (c *checkup) Setup(ctx context.Context) error {
 	)
 
 	netAttachDef, err := c.client.GetNetworkAttachmentDefinition(
+		ctx,
 		c.params.NetworkAttachmentDefinitionNamespace,
 		c.params.NetworkAttachmentDefinitionName)
 	if err != nil {

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
@@ -342,7 +342,10 @@ func (c *clientStub) GetVirtualMachineInstance(_ context.Context, _, name string
 	return c.createdVmis[name], c.failGetVmi
 }
 
-func (c *clientStub) CreateVirtualMachineInstance(_ string, v *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error) {
+func (c *clientStub) CreateVirtualMachineInstance(
+	_ context.Context,
+	_ string,
+	v *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error) {
 	if c.failCreateVmi != nil {
 		return nil, c.failCreateVmi
 	}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
@@ -213,10 +213,10 @@ func TestCheckupSetupShouldCreateOwnerReference(t *testing.T) {
 	sourceVMIName := testClient.SourceVMIName()
 	targetVMIName := testClient.TargetVMIName()
 
-	sourceVMI, err := testClient.GetVirtualMachineInstance(testNamespace, sourceVMIName)
+	sourceVMI, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, sourceVMIName)
 	assert.NoError(t, err)
 
-	targetVMI, err := testClient.GetVirtualMachineInstance(testNamespace, targetVMIName)
+	targetVMI, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, targetVMIName)
 	assert.NoError(t, err)
 
 	assertOwnerReferenceExists(t, sourceVMI, testPodName, testPodUID)
@@ -243,10 +243,10 @@ func TestCheckupSetupShouldNotCreateOwnerReferenceWhenPodUIDIsEmpty(t *testing.T
 	sourceVMIName := testClient.SourceVMIName()
 	targetVMIName := testClient.TargetVMIName()
 
-	sourceVMI, err := testClient.GetVirtualMachineInstance(testNamespace, sourceVMIName)
+	sourceVMI, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, sourceVMIName)
 	assert.NoError(t, err)
 
-	targetVMI, err := testClient.GetVirtualMachineInstance(testNamespace, targetVMIName)
+	targetVMI, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, targetVMIName)
 	assert.NoError(t, err)
 
 	assertOwnerReferenceDoesNotExists(t, sourceVMI, testPodName, emptyPodUID)
@@ -254,7 +254,7 @@ func TestCheckupSetupShouldNotCreateOwnerReferenceWhenPodUIDIsEmpty(t *testing.T
 }
 
 func assertVmiPodAntiAffinityExist(t *testing.T, testClient *clientStub, vmiName string) {
-	actualVmi, err := testClient.GetVirtualMachineInstance(testNamespace, vmiName)
+	actualVmi, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, vmiName)
 	assert.NoError(t, err)
 	assert.NotNil(t, actualVmi.Spec.Affinity.PodAntiAffinity)
 	expectedPodAntiAffinity := vmi.NewPodAntiAffinity(vmi.Label{Key: checkup.LabelLatencyCheckUID, Value: testCheckupUID})
@@ -262,14 +262,14 @@ func assertVmiPodAntiAffinityExist(t *testing.T, testClient *clientStub, vmiName
 }
 
 func assertVmiPodAntiAffinityNotExist(t *testing.T, testClient *clientStub, name string) {
-	actualVmi, err := testClient.GetVirtualMachineInstance(testNamespace, name)
+	actualVmi, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, name)
 	assert.NoError(t, err)
 
 	assert.Nil(t, actualVmi.Spec.Affinity.PodAntiAffinity)
 }
 
 func assertVmiNodeAffinityExist(t *testing.T, testClient *clientStub, vmiName, nodeName string) {
-	actualVmi, err := testClient.GetVirtualMachineInstance(testNamespace, vmiName)
+	actualVmi, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, vmiName)
 	assert.NoError(t, err)
 
 	actualVmiNodeAffinity := actualVmi.Spec.Affinity.NodeAffinity
@@ -280,7 +280,7 @@ func assertVmiNodeAffinityExist(t *testing.T, testClient *clientStub, vmiName, n
 }
 
 func assertVmiNodeAffinityNotExist(t *testing.T, testClient *clientStub, name string) {
-	actualVmi, err := testClient.GetVirtualMachineInstance(testNamespace, name)
+	actualVmi, err := testClient.GetVirtualMachineInstance(context.Background(), testNamespace, name)
 	assert.NoError(t, err)
 
 	assert.Nil(t, actualVmi.Spec.Affinity.NodeAffinity)
@@ -338,7 +338,7 @@ type clientStub struct {
 	failDeleteVmi       error
 }
 
-func (c *clientStub) GetVirtualMachineInstance(_, name string) (*kvcorev1.VirtualMachineInstance, error) {
+func (c *clientStub) GetVirtualMachineInstance(_ context.Context, _, name string) (*kvcorev1.VirtualMachineInstance, error) {
 	return c.createdVmis[name], c.failGetVmi
 }
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
@@ -367,7 +367,7 @@ func (c *clientStub) SerialConsole(_, _ string, _ time.Duration) (kubecli.Stream
 	return nil, nil
 }
 
-func (c *clientStub) GetNetworkAttachmentDefinition(_, _ string) (*netattdefv1.NetworkAttachmentDefinition, error) {
+func (c *clientStub) GetNetworkAttachmentDefinition(_ context.Context, _, _ string) (*netattdefv1.NetworkAttachmentDefinition, error) {
 	return c.returnNetAttachDef, c.failGetNetAttachDef
 }
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
@@ -359,7 +359,7 @@ func (c *clientStub) CreateVirtualMachineInstance(
 	return v, nil
 }
 
-func (c *clientStub) DeleteVirtualMachineInstance(_, _ string) error {
+func (c *clientStub) DeleteVirtualMachineInstance(_ context.Context, _, _ string) error {
 	return c.failDeleteVmi
 }
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/client/client.go
@@ -117,6 +117,8 @@ func (c *Client) SerialConsole(namespace, vmiName string, timeout time.Duration)
 	return c.KubevirtClient.VirtualMachineInstance(namespace).SerialConsole(vmiName, &kubecli.SerialConsoleOptions{ConnectionTimeout: timeout})
 }
 
-func (c *Client) GetNetworkAttachmentDefinition(namespace, name string) (*netattdefv1.NetworkAttachmentDefinition, error) {
-	return c.K8sCniCncfIoV1Interface.NetworkAttachmentDefinitions(namespace).Get(context.Background(), name, metav1.GetOptions{})
+func (c *Client) GetNetworkAttachmentDefinition(
+	ctx context.Context,
+	namespace, name string) (*netattdefv1.NetworkAttachmentDefinition, error) {
+	return c.K8sCniCncfIoV1Interface.NetworkAttachmentDefinitions(namespace).Get(ctx, name, metav1.GetOptions{})
 }

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -278,7 +278,7 @@ func (c *fakeClient) SerialConsole(namespace, vmiName string, timeout time.Durat
 	return nil, nil
 }
 
-func (c *fakeClient) GetNetworkAttachmentDefinition(_, _ string) (*netattdefv1.NetworkAttachmentDefinition, error) {
+func (c *fakeClient) GetNetworkAttachmentDefinition(_ context.Context, _, _ string) (*netattdefv1.NetworkAttachmentDefinition, error) {
 	return c.returnNetAttachDef, nil
 }
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -250,6 +250,7 @@ func (c *fakeClient) GetVirtualMachineInstance(_ context.Context, namespace, nam
 // adds VirtualMachineInstanceAgentConnected condition to the VMI status and
 // the node name according to node affinity rule with 'kubernetes.io/hostname' label selector.
 func (c *fakeClient) CreateVirtualMachineInstance(
+	_ context.Context,
 	namespace string,
 	vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error) {
 	vmi.Status.Interfaces = append(vmi.Status.Interfaces, kvcorev1.VirtualMachineInstanceNetworkInterface{

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -238,7 +238,7 @@ func newFakeClient() *fakeClient {
 	}
 }
 
-func (c *fakeClient) GetVirtualMachineInstance(namespace, name string) (*kvcorev1.VirtualMachineInstance, error) {
+func (c *fakeClient) GetVirtualMachineInstance(_ context.Context, namespace, name string) (*kvcorev1.VirtualMachineInstance, error) {
 	vmi, exists := c.vmiTracker[vmiKey(namespace, name)]
 	if !exists {
 		return nil, k8serrors.NewNotFound(kvcorev1.Resource("VirtualMachineInstance"), "")

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -269,7 +269,7 @@ func (c *fakeClient) CreateVirtualMachineInstance(
 	return vmi, nil
 }
 
-func (c *fakeClient) DeleteVirtualMachineInstance(namespace, name string) error {
+func (c *fakeClient) DeleteVirtualMachineInstance(_ context.Context, namespace, name string) error {
 	delete(c.vmiTracker, vmiKey(namespace, name))
 	return nil
 }

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
@@ -36,7 +36,10 @@ import (
 
 type KubevirtVmisClient interface {
 	GetVirtualMachineInstance(ctx context.Context, namespace, name string) (*kvcorev1.VirtualMachineInstance, error)
-	CreateVirtualMachineInstance(namespace string, vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error)
+	CreateVirtualMachineInstance(
+		ctx context.Context,
+		namespace string,
+		vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error)
 	DeleteVirtualMachineInstance(namespace, name string) error
 	SerialConsole(namespace, vmiName string, timeout time.Duration) (kubecli.StreamInterface, error)
 	GetNetworkAttachmentDefinition(namespace, name string) (*netattdefv1.NetworkAttachmentDefinition, error)
@@ -44,7 +47,7 @@ type KubevirtVmisClient interface {
 
 func Start(c KubevirtVmisClient, namespace string, vmi *kvcorev1.VirtualMachineInstance) error {
 	log.Printf("starting VMI %s/%s..", namespace, vmi.Name)
-	if _, err := c.CreateVirtualMachineInstance(namespace, vmi); err != nil {
+	if _, err := c.CreateVirtualMachineInstance(context.Background(), namespace, vmi); err != nil {
 		return fmt.Errorf("failed to start VMI %s/%s: %v", vmi.Namespace, vmi.Name, err)
 	}
 	return nil

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
@@ -40,7 +40,7 @@ type KubevirtVmisClient interface {
 		ctx context.Context,
 		namespace string,
 		vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error)
-	DeleteVirtualMachineInstance(namespace, name string) error
+	DeleteVirtualMachineInstance(ctx context.Context, namespace, name string) error
 	SerialConsole(namespace, vmiName string, timeout time.Duration) (kubecli.StreamInterface, error)
 	GetNetworkAttachmentDefinition(namespace, name string) (*netattdefv1.NetworkAttachmentDefinition, error)
 }
@@ -80,7 +80,7 @@ func vmiIPAddressExists(vmi *kvcorev1.VirtualMachineInstance) bool {
 func Delete(c KubevirtVmisClient, namespace, name string) error {
 	log.Printf("deleting VMI %s/%s..\n", namespace, name)
 
-	if err := c.DeleteVirtualMachineInstance(namespace, name); err != nil {
+	if err := c.DeleteVirtualMachineInstance(context.Background(), namespace, name); err != nil {
 		return fmt.Errorf("failed to delete VMI %s/%s: %v", namespace, name, err)
 	}
 	return nil

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
@@ -42,7 +42,7 @@ type KubevirtVmisClient interface {
 		vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error)
 	DeleteVirtualMachineInstance(ctx context.Context, namespace, name string) error
 	SerialConsole(namespace, vmiName string, timeout time.Duration) (kubecli.StreamInterface, error)
-	GetNetworkAttachmentDefinition(namespace, name string) (*netattdefv1.NetworkAttachmentDefinition, error)
+	GetNetworkAttachmentDefinition(ctx context.Context, namespace, name string) (*netattdefv1.NetworkAttachmentDefinition, error)
 }
 
 func Start(c KubevirtVmisClient, namespace string, vmi *kvcorev1.VirtualMachineInstance) error {

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
@@ -35,7 +35,7 @@ import (
 )
 
 type KubevirtVmisClient interface {
-	GetVirtualMachineInstance(namespace, name string) (*kvcorev1.VirtualMachineInstance, error)
+	GetVirtualMachineInstance(ctx context.Context, namespace, name string) (*kvcorev1.VirtualMachineInstance, error)
 	CreateVirtualMachineInstance(namespace string, vmi *kvcorev1.VirtualMachineInstance) (*kvcorev1.VirtualMachineInstance, error)
 	DeleteVirtualMachineInstance(namespace, name string) error
 	SerialConsole(namespace, vmiName string, timeout time.Duration) (kubecli.StreamInterface, error)
@@ -56,7 +56,7 @@ func WaitForStatusIPAddress(ctx context.Context, c KubevirtVmisClient, namespace
 
 	conditionFn := func(ctx context.Context) (bool, error) {
 		var err error
-		updatedVMI, err = c.GetVirtualMachineInstance(namespace, name)
+		updatedVMI, err = c.GetVirtualMachineInstance(ctx, namespace, name)
 		if err != nil {
 			return false, nil
 		}
@@ -87,7 +87,7 @@ func WaitForVmiDispose(ctx context.Context, c KubevirtVmisClient, namespace, nam
 	log.Printf("waiting for VMI %s/%s to dispose..\n", namespace, name)
 
 	conditionFn := func(ctx context.Context) (bool, error) {
-		_, err := c.GetVirtualMachineInstance(namespace, name)
+		_, err := c.GetVirtualMachineInstance(ctx, namespace, name)
 		if k8serrors.IsNotFound(err) {
 			return true, nil
 		}


### PR DESCRIPTION
Currently, functions from the client layer does not accept a context as a parameter, thus making them un-cancelable from the outside.

Add a context parameter to applicable functions from the client layer, in order to be able to cancel them from the outside.

This will be used in a follow-up PR to enforce the timeout parameter specified by the user.