### PR TITLE
vmlatency, README: Update section about invalid params

### DIFF
--- a/checkups/kubevirt-vm-latency/README.md
+++ b/checkups/kubevirt-vm-latency/README.md
@@ -224,10 +224,10 @@ status.succeeded: "true"
 status.failureReason: ""
 ```
 
-In case an environment variable is missing (e.g: `MAX_DESIRED_LATENCY_MILLISECONDS`:
+In case a parameter is missing or contains an empty string (""):
 ```yaml
 status.succeeded: "false"
-status.failureReason: "MAX_DESIRED_LATENCY_MILLISECONDS environment variable is missing"
+status.failureReason: "\"<param_name>\" parameter is invalid"
 ```
 
 In case of a connectivity issues between the VMs:


### PR DESCRIPTION
Following PR https://github.com/kiagnose/kiagnose/pull/219, we now treat our inputs as parameters
and not as environment variables.

Update the error message accordingly.

Signed-off-by: Orel Misan <omisan@redhat.com>