### PR TITLE
vmlatency: Partially respect the user-supplied timeout

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -73,11 +73,7 @@ const (
 )
 
 func (c *checkup) Setup(ctx context.Context) error {
-	const (
-		errMessagePrefix = "setup"
-
-		defaultSetupTimeout = time.Minute * 10
-	)
+	const errMessagePrefix = "setup"
 
 	netAttachDef, err := c.client.GetNetworkAttachmentDefinition(
 		ctx,
@@ -100,13 +96,11 @@ func (c *checkup) Setup(ctx context.Context) error {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
 
-	waitCtx, cancel := context.WithTimeout(ctx, defaultSetupTimeout)
-	defer cancel()
-	if c.targetVM, err = vmi.WaitForStatusIPAddress(waitCtx, c.client, c.namespace, targetVmi.Name); err != nil {
+	if c.targetVM, err = vmi.WaitForStatusIPAddress(ctx, c.client, c.namespace, targetVmi.Name); err != nil {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
 
-	if c.sourceVM, err = vmi.WaitForStatusIPAddress(waitCtx, c.client, c.namespace, sourceVmi.Name); err != nil {
+	if c.sourceVM, err = vmi.WaitForStatusIPAddress(ctx, c.client, c.namespace, sourceVmi.Name); err != nil {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -93,10 +93,10 @@ func (c *checkup) Setup(ctx context.Context) error {
 	sourceVmi := newLatencyCheckVmi(c.uid, sourceVMIName, c.params.SourceNodeName, c.params.PodName, c.params.PodUID, netAttachDef)
 	targetVmi := newLatencyCheckVmi(c.uid, targetVMIName, c.params.TargetNodeName, c.params.PodName, c.params.PodUID, netAttachDef)
 
-	if err = vmi.Start(c.client, c.namespace, sourceVmi); err != nil {
+	if err = vmi.Start(ctx, c.client, c.namespace, sourceVmi); err != nil {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
-	if err = vmi.Start(c.client, c.namespace, targetVmi); err != nil {
+	if err = vmi.Start(ctx, c.client, c.namespace, targetVmi); err != nil {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher.go
@@ -68,7 +68,7 @@ func (l launcher) Run(ctx context.Context) (runErr error) {
 		runErr = failureReason(runStatus)
 	}()
 
-	if err := l.checkup.Setup(context.Background()); err != nil {
+	if err := l.checkup.Setup(ctx); err != nil {
 		runStatus.FailureReason = append(runStatus.FailureReason, err.Error())
 		return err
 	}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher.go
@@ -51,7 +51,7 @@ func New(checkup checkup, reporter reporter) launcher {
 	}
 }
 
-func (l launcher) Run() (runErr error) {
+func (l launcher) Run(ctx context.Context) (runErr error) {
 	var runStatus status.Status
 	runStatus.StartTimestamp = time.Now()
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher_test.go
@@ -62,7 +62,7 @@ func TestLauncherShouldFail(t *testing.T) {
 	)
 	testLauncher := launcher.New(testCheckup, &reporterStub{})
 
-	assert.ErrorContains(t, testLauncher.Run(), errorCheck.Error())
+	assert.ErrorContains(t, testLauncher.Run(context.Background()), errorCheck.Error())
 }
 
 func TestLauncherShouldRunSuccessfully(t *testing.T) {
@@ -76,23 +76,23 @@ func TestLauncherShouldRunSuccessfully(t *testing.T) {
 	)
 	testLauncher := launcher.New(testCheckup, &reporterStub{})
 
-	assert.NoError(t, testLauncher.Run())
+	assert.NoError(t, testLauncher.Run(context.Background()))
 }
 
 func TestLauncherShould(t *testing.T) {
 	t.Run("run successfully", func(t *testing.T) {
 		testLauncher := launcher.New(checkupStub{}, &reporterStub{})
-		assert.NoError(t, testLauncher.Run())
+		assert.NoError(t, testLauncher.Run(context.Background()))
 	})
 
 	t.Run("fail when report is failing", func(t *testing.T) {
 		testLauncher := launcher.New(checkupStub{}, &reporterStub{failReport: errorReport})
-		assert.ErrorContains(t, testLauncher.Run(), errorReport.Error())
+		assert.ErrorContains(t, testLauncher.Run(context.Background()), errorReport.Error())
 	})
 
 	t.Run("fail when setup is failing", func(t *testing.T) {
 		testLauncher := launcher.New(checkupStub{failSetup: errorSetup}, &reporterStub{})
-		assert.ErrorContains(t, testLauncher.Run(), errorSetup.Error())
+		assert.ErrorContains(t, testLauncher.Run(context.Background()), errorSetup.Error())
 	})
 
 	t.Run("fail when setup and 2nd report are failing", func(t *testing.T) {
@@ -100,19 +100,19 @@ func TestLauncherShould(t *testing.T) {
 			checkupStub{failSetup: errorSetup},
 			&reporterStub{failReport: errorReport, failOnSecondReport: true},
 		)
-		err := testLauncher.Run()
+		err := testLauncher.Run(context.Background())
 		assert.ErrorContains(t, err, errorSetup.Error())
 		assert.ErrorContains(t, err, errorReport.Error())
 	})
 
 	t.Run("fail when run is failing", func(t *testing.T) {
 		testLauncher := launcher.New(checkupStub{failRun: errorRun}, &reporterStub{})
-		assert.ErrorContains(t, testLauncher.Run(), errorRun.Error())
+		assert.ErrorContains(t, testLauncher.Run(context.Background()), errorRun.Error())
 	})
 
 	t.Run("fail when teardown is failing", func(t *testing.T) {
 		testLauncher := launcher.New(checkupStub{failTeardown: errorTeardown}, &reporterStub{})
-		assert.ErrorContains(t, testLauncher.Run(), errorTeardown.Error())
+		assert.ErrorContains(t, testLauncher.Run(context.Background()), errorTeardown.Error())
 	})
 
 	t.Run("fail when run and report are failing", func(t *testing.T) {
@@ -120,7 +120,7 @@ func TestLauncherShould(t *testing.T) {
 			checkupStub{failRun: errorRun},
 			&reporterStub{failReport: errorReport, failOnSecondReport: true},
 		)
-		err := testLauncher.Run()
+		err := testLauncher.Run(context.Background())
 		assert.ErrorContains(t, err, errorRun.Error())
 		assert.ErrorContains(t, err, errorReport.Error())
 	})
@@ -130,7 +130,7 @@ func TestLauncherShould(t *testing.T) {
 			checkupStub{failTeardown: errorTeardown},
 			&reporterStub{failReport: errorReport, failOnSecondReport: true},
 		)
-		err := testLauncher.Run()
+		err := testLauncher.Run(context.Background())
 		assert.ErrorContains(t, err, errorTeardown.Error())
 		assert.ErrorContains(t, err, errorReport.Error())
 	})
@@ -140,7 +140,7 @@ func TestLauncherShould(t *testing.T) {
 			checkupStub{failRun: errorRun, failTeardown: errorTeardown},
 			&reporterStub{failReport: errorReport, failOnSecondReport: true},
 		)
-		err := testLauncher.Run()
+		err := testLauncher.Run(context.Background())
 		assert.ErrorContains(t, err, errorRun.Error())
 		assert.ErrorContains(t, err, errorTeardown.Error())
 		assert.ErrorContains(t, err, errorReport.Error())
@@ -166,7 +166,7 @@ func TestLauncherShouldSuccessfullyProduceStatusResults(t *testing.T) {
 	)
 	testLauncher := launcher.New(testCheckup, testReporter)
 
-	assert.NoError(t, testLauncher.Run())
+	assert.NoError(t, testLauncher.Run(context.Background()))
 
 	expectedResults := status.Results{
 		SourceNode: sourceNodeName,

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
@@ -45,9 +45,9 @@ type KubevirtVmisClient interface {
 	GetNetworkAttachmentDefinition(ctx context.Context, namespace, name string) (*netattdefv1.NetworkAttachmentDefinition, error)
 }
 
-func Start(c KubevirtVmisClient, namespace string, vmi *kvcorev1.VirtualMachineInstance) error {
+func Start(ctx context.Context, c KubevirtVmisClient, namespace string, vmi *kvcorev1.VirtualMachineInstance) error {
 	log.Printf("starting VMI %s/%s..", namespace, vmi.Name)
-	if _, err := c.CreateVirtualMachineInstance(context.Background(), namespace, vmi); err != nil {
+	if _, err := c.CreateVirtualMachineInstance(ctx, namespace, vmi); err != nil {
 		return fmt.Errorf("failed to start VMI %s/%s: %v", vmi.Namespace, vmi.Name, err)
 	}
 	return nil

--- a/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/mainflow.go
@@ -20,6 +20,8 @@
 package vmlatency
 
 import (
+	"context"
+
 	kconfig "github.com/kiagnose/kiagnose/kiagnose/config"
 
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/checkup"
@@ -50,5 +52,9 @@ func Run(rawEnv map[string]string, namespace string) error {
 		checkup.New(c, baseConfig.UID, namespace, cfg, latency.New(c)),
 		reporter.New(c, baseConfig.ConfigMapNamespace, baseConfig.ConfigMapName),
 	)
-	return l.Run()
+
+	ctx, cancel := context.WithTimeout(context.Background(), baseConfig.Timeout)
+	defer cancel()
+
+	return l.Run(ctx)
 }


### PR DESCRIPTION
Currently, the user-supplied `timeout` field is not respected.

Create a context with timeout based on the user-supplied `timeout` field, and pass it along to the checkup's `Setup()` method.

Follow-up PR(s) will pass this context to the `Run()` and `Teardown()` methods, and include e2e tests for the completed feature.

~~Depends on PR #230.~~