### PR TITLE
vmlatency: Respect the user-supplied timeout in teardown

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -163,7 +163,7 @@ func (c *checkup) Run() error {
 	return nil
 }
 
-func (c *checkup) Teardown(waitCtx context.Context) error {
+func (c *checkup) Teardown(ctx context.Context) error {
 	const (
 		errMessagePrefix = "teardown"
 
@@ -171,15 +171,15 @@ func (c *checkup) Teardown(waitCtx context.Context) error {
 	)
 
 	var teardownErrors []string
-	if err := vmi.Delete(c.client, c.namespace, c.sourceVM.Name); err != nil {
+	if err := vmi.Delete(ctx, c.client, c.namespace, c.sourceVM.Name); err != nil {
 		teardownErrors = append(teardownErrors, fmt.Sprintf("'%s/%s': %v", c.namespace, c.sourceVM.Name, err))
 	}
 
-	if err := vmi.Delete(c.client, c.namespace, c.targetVM.Name); err != nil {
+	if err := vmi.Delete(ctx, c.client, c.namespace, c.targetVM.Name); err != nil {
 		teardownErrors = append(teardownErrors, fmt.Sprintf("'%s/%s': %v", c.namespace, c.targetVM.Name, err))
 	}
 
-	waitCtx, cancel := context.WithTimeout(waitCtx, defaultTeardownTimeout)
+	waitCtx, cancel := context.WithTimeout(ctx, defaultTeardownTimeout)
 	defer cancel()
 
 	if err := vmi.WaitForVmiDispose(waitCtx, c.client, c.namespace, c.sourceVM.Name); err != nil {

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -164,11 +164,7 @@ func (c *checkup) Run() error {
 }
 
 func (c *checkup) Teardown(ctx context.Context) error {
-	const (
-		errMessagePrefix = "teardown"
-
-		defaultTeardownTimeout = time.Minute * 3
-	)
+	const errMessagePrefix = "teardown"
 
 	var teardownErrors []string
 	if err := vmi.Delete(ctx, c.client, c.namespace, c.sourceVM.Name); err != nil {
@@ -179,14 +175,11 @@ func (c *checkup) Teardown(ctx context.Context) error {
 		teardownErrors = append(teardownErrors, fmt.Sprintf("'%s/%s': %v", c.namespace, c.targetVM.Name, err))
 	}
 
-	waitCtx, cancel := context.WithTimeout(ctx, defaultTeardownTimeout)
-	defer cancel()
-
-	if err := vmi.WaitForVmiDispose(waitCtx, c.client, c.namespace, c.sourceVM.Name); err != nil {
+	if err := vmi.WaitForVmiDispose(ctx, c.client, c.namespace, c.sourceVM.Name); err != nil {
 		teardownErrors = append(teardownErrors, fmt.Sprintf("'%s/%s': %v", c.namespace, c.sourceVM.Name, err))
 	}
 
-	if err := vmi.WaitForVmiDispose(waitCtx, c.client, c.namespace, c.targetVM.Name); err != nil {
+	if err := vmi.WaitForVmiDispose(ctx, c.client, c.namespace, c.targetVM.Name); err != nil {
 		teardownErrors = append(teardownErrors, fmt.Sprintf("'%s/%s': %v", c.namespace, c.targetVM.Name, err))
 	}
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/launcher/launcher.go
@@ -74,7 +74,7 @@ func (l launcher) Run(ctx context.Context) (runErr error) {
 	}
 
 	defer func() {
-		if err := l.checkup.Teardown(context.Background()); err != nil {
+		if err := l.checkup.Teardown(ctx); err != nil {
 			runStatus.FailureReason = append(runStatus.FailureReason, err.Error())
 		}
 	}()

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/vmi/operation.go
@@ -77,10 +77,10 @@ func vmiIPAddressExists(vmi *kvcorev1.VirtualMachineInstance) bool {
 	return len(vmi.Status.Interfaces) > 0 && vmi.Status.Interfaces[0].IP != ""
 }
 
-func Delete(c KubevirtVmisClient, namespace, name string) error {
+func Delete(ctx context.Context, c KubevirtVmisClient, namespace, name string) error {
 	log.Printf("deleting VMI %s/%s..\n", namespace, name)
 
-	if err := c.DeleteVirtualMachineInstance(context.Background(), namespace, name); err != nil {
+	if err := c.DeleteVirtualMachineInstance(ctx, namespace, name); err != nil {
 		return fmt.Errorf("failed to delete VMI %s/%s: %v", namespace, name, err)
 	}
 	return nil


### PR DESCRIPTION
This is a follow-up to PR #234.

Pass the context with timeout based on the user-supplied timeout field, to the checkup's `Teardown()` method.

~~Depends on PR #234.~~