### PR TITLE
vmlatency, client: Add a context helper wrapper

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/client/context.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/client/context.go
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the kiagnose project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package client
+
+import "context"
+
+func withContext(ctx context.Context, f func()) error {
+	done := make(chan struct{}, 1)
+
+	go func() {
+		f()
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}


### PR DESCRIPTION
The functionality of adding a context to a sync call has a repeating structure and logic.

Extract the context wrapping logic to a helper function.

This change is inspired by the direction #236 took with some adjustments.

---

Note: If this one works, I am fine with changing the original PR and dropping this one.