### PR TITLE
configmap: Add Create option to library

### DIFF
--- a/kiagnose/configmap/configmap.go
+++ b/kiagnose/configmap/configmap.go
@@ -34,3 +34,7 @@ func Get(client kubernetes.Interface, namespace, name string) (*corev1.ConfigMap
 func Update(client kubernetes.Interface, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 	return client.CoreV1().ConfigMaps(configMap.Namespace).Update(context.Background(), configMap, metav1.UpdateOptions{})
 }
+
+func Create(client kubernetes.Interface, configmap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return client.CoreV1().ConfigMaps(configmap.Namespace).Create(context.Background(), configmap, metav1.CreateOptions{})
+}


### PR DESCRIPTION
This option will be needed for the kubevirt-dpdk-checkup.