### PR TITLE
vmlatency: Fix latency comparison

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -181,7 +181,10 @@ func (c *checkup) Run() error {
 	actualMaxLatency := c.results.MaxLatency
 	maxLatencyDesired := c.params.DesiredMaxLatency
 	if actualMaxLatency > maxLatencyDesired {
-		return fmt.Errorf("run : actual max latency (%d) is greater then desired (%d)", actualMaxLatency, maxLatencyDesired)
+		return fmt.Errorf("run : actual max latency %q is greater than desired %q",
+			actualMaxLatency.String(),
+			maxLatencyDesired.String(),
+		)
 	}
 
 	return nil

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup.go
@@ -178,8 +178,8 @@ func (c *checkup) Run() error {
 	c.results.MaxLatency = c.checker.MaxLatency()
 	c.results.MeasurementDuration = c.checker.CheckDuration()
 
-	actualMaxLatency := c.results.MaxLatency.Milliseconds()
-	maxLatencyDesired := int64(c.params.DesiredMaxLatencyMilliseconds)
+	actualMaxLatency := c.results.MaxLatency
+	maxLatencyDesired := c.params.DesiredMaxLatency
 	if actualMaxLatency > maxLatencyDesired {
 		return fmt.Errorf("run : actual max latency (%d) is greater then desired (%d)", actualMaxLatency, maxLatencyDesired)
 	}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/checkup/checkup_test.go
@@ -323,7 +323,7 @@ func newTestsCheckupParameters() config.Config {
 		TargetNodeName:                       "",
 		SourceNodeName:                       "",
 		SampleDurationSeconds:                testSampleDurationSeconds,
-		DesiredMaxLatencyMilliseconds:        0,
+		DesiredMaxLatency:                    0,
 	}
 }
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"math"
 	"strconv"
+	"time"
 
 	kconfig "github.com/kiagnose/kiagnose/kiagnose/config"
 )
@@ -56,7 +57,7 @@ type Config struct {
 	TargetNodeName                       string
 	SourceNodeName                       string
 	SampleDurationSeconds                int
-	DesiredMaxLatencyMilliseconds        int
+	DesiredMaxLatency                    time.Duration
 }
 
 var (
@@ -80,7 +81,7 @@ func New(baseConfig kconfig.Config) (Config, error) {
 		PodName:                              baseConfig.PodName,
 		PodUID:                               baseConfig.PodUID,
 		SampleDurationSeconds:                DefaultSampleDurationSeconds,
-		DesiredMaxLatencyMilliseconds:        DefaultDesiredMaxLatencyMilliseconds,
+		DesiredMaxLatency:                    DefaultDesiredMaxLatencyMilliseconds,
 		NetworkAttachmentDefinitionNamespace: readConfig(baseConfig.Params, NetworkNamespaceParamName, NetworkNamespaceDeprecatedParamName),
 		NetworkAttachmentDefinitionName:      readConfig(baseConfig.Params, NetworkNameParamName, NetworkNameDeprecatedParamName),
 		SourceNodeName:                       readConfig(baseConfig.Params, SourceNodeNameParamName, SourceNodeNameDeprecatedParamName),
@@ -95,9 +96,13 @@ func New(baseConfig kconfig.Config) (Config, error) {
 	}
 
 	if v := readConfig(baseConfig.Params, DesiredMaxLatencyMillisecondsParamName, DesiredMaxLatencyMillisecondsDeprecatedParamName); v != "" {
-		if newConfig.DesiredMaxLatencyMilliseconds, err = strconv.Atoi(v); err != nil {
+		var rawDesiredMaxLatencyMilliseconds int
+
+		if rawDesiredMaxLatencyMilliseconds, err = strconv.Atoi(v); err != nil {
 			return Config{}, fmt.Errorf("%q parameter is invalid: %v", DesiredMaxLatencyMillisecondsParamName, err)
 		}
+
+		newConfig.DesiredMaxLatency = time.Duration(rawDesiredMaxLatencyMilliseconds) * time.Millisecond
 	}
 
 	err = newConfig.validate()

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/config/config_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 
 	assert "github.com/stretchr/testify/require"
 
@@ -63,7 +64,7 @@ func TestCreateConfigFromParamsShould(t *testing.T) {
 				SampleDurationSeconds:                config.DefaultSampleDurationSeconds,
 				NetworkAttachmentDefinitionName:      testNetAttachDefName,
 				NetworkAttachmentDefinitionNamespace: testNamespace,
-				DesiredMaxLatencyMilliseconds:        testDesiredMaxLatencyMilliseconds,
+				DesiredMaxLatency:                    testDesiredMaxLatencyMilliseconds * time.Millisecond,
 			},
 		},
 		{
@@ -76,7 +77,7 @@ func TestCreateConfigFromParamsShould(t *testing.T) {
 			expectedConfig: config.Config{
 				PodName:                              testPodName,
 				PodUID:                               testPodUID,
-				DesiredMaxLatencyMilliseconds:        config.DefaultDesiredMaxLatencyMilliseconds,
+				DesiredMaxLatency:                    config.DefaultDesiredMaxLatencyMilliseconds,
 				NetworkAttachmentDefinitionName:      testNetAttachDefName,
 				NetworkAttachmentDefinitionNamespace: testNamespace,
 				SampleDurationSeconds:                testSampleDurationSeconds,
@@ -94,7 +95,7 @@ func TestCreateConfigFromParamsShould(t *testing.T) {
 			expectedConfig: config.Config{
 				PodName:                              testPodName,
 				PodUID:                               testPodUID,
-				DesiredMaxLatencyMilliseconds:        config.DefaultDesiredMaxLatencyMilliseconds,
+				DesiredMaxLatency:                    config.DefaultDesiredMaxLatencyMilliseconds,
 				NetworkAttachmentDefinitionName:      testNetAttachDefName,
 				NetworkAttachmentDefinitionNamespace: testNamespace,
 				SampleDurationSeconds:                testSampleDurationSeconds,
@@ -143,7 +144,7 @@ func TestCreateConfigShouldPreferNonDeprecatedParameters(t *testing.T) {
 				TargetNodeName:                       testSourceNodeName,
 				SourceNodeName:                       testTargetNodeName,
 				SampleDurationSeconds:                testSampleDurationSeconds,
-				DesiredMaxLatencyMilliseconds:        testDesiredMaxLatencyMilliseconds,
+				DesiredMaxLatency:                    testDesiredMaxLatencyMilliseconds * time.Millisecond,
 			},
 		},
 		{
@@ -164,7 +165,7 @@ func TestCreateConfigShouldPreferNonDeprecatedParameters(t *testing.T) {
 				TargetNodeName:                       testSourceNodeName,
 				SourceNodeName:                       testTargetNodeName,
 				SampleDurationSeconds:                testSampleDurationSeconds,
-				DesiredMaxLatencyMilliseconds:        testDesiredMaxLatencyMilliseconds,
+				DesiredMaxLatency:                    testDesiredMaxLatencyMilliseconds * time.Millisecond,
 			},
 		},
 	}

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser.go
@@ -41,7 +41,7 @@ func ParsePingResults(pingResult string) Results {
 	const (
 		errMessagePrefix = "ping parser"
 
-		millisecondsPrefix = "ms"
+		millisecondsSuffix = "ms"
 	)
 	var results Results
 	var err error
@@ -57,7 +57,7 @@ func ParsePingResults(pingResult string) Results {
 			log.Printf("%s: failed to parse 'time': %v", errMessagePrefix, err)
 		}
 
-		if results.Time, err = time.ParseDuration(fmt.Sprintf("%s%s", strings.TrimSpace(item[6]), millisecondsPrefix)); err != nil {
+		if results.Time, err = time.ParseDuration(fmt.Sprintf("%s%s", strings.TrimSpace(item[6]), millisecondsSuffix)); err != nil {
 			log.Printf("%s: failed to parse 'time': %v", errMessagePrefix, err)
 		}
 	}
@@ -65,15 +65,15 @@ func ParsePingResults(pingResult string) Results {
 	latencyPattern := regexp.MustCompile(`(round-trip|rtt)\s+\S+\s*=\s*([0-9.]+)/([0-9.]+)/([0-9.]+)(/[0-9.]+)?\s*ms`)
 	latencyPatternMatches := latencyPattern.FindAllStringSubmatch(pingResult, -1)
 	for _, item := range latencyPatternMatches {
-		if results.Min, err = time.ParseDuration(fmt.Sprintf("%s%s", strings.TrimSpace(item[2]), millisecondsPrefix)); err != nil {
+		if results.Min, err = time.ParseDuration(fmt.Sprintf("%s%s", strings.TrimSpace(item[2]), millisecondsSuffix)); err != nil {
 			log.Printf("%s: failed to parse 'min': %v", errMessagePrefix, err)
 		}
 
-		if results.Average, err = time.ParseDuration(fmt.Sprintf("%s%s", strings.TrimSpace(item[3]), millisecondsPrefix)); err != nil {
+		if results.Average, err = time.ParseDuration(fmt.Sprintf("%s%s", strings.TrimSpace(item[3]), millisecondsSuffix)); err != nil {
 			log.Printf("%s: failed to parse 'avg': %v", errMessagePrefix, err)
 		}
 
-		if results.Max, err = time.ParseDuration(fmt.Sprintf("%s%s", strings.TrimSpace(item[4]), millisecondsPrefix)); err != nil {
+		if results.Max, err = time.ParseDuration(fmt.Sprintf("%s%s", strings.TrimSpace(item[4]), millisecondsSuffix)); err != nil {
 			log.Printf("%s: failed to parse 'max': %v", errMessagePrefix, err)
 		}
 	}


### PR DESCRIPTION
Currently, if the actual measured latency is less than 1ms, it is considered as 0ms.
This created a small bug[1] when the max desired latency was 0ms.

Improve the comparison of the max desired latency and the actual measured latency.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2156392 