### PR TITLE
vmlatency, Dockerfile: Update base image to ubi-minimal9

### DIFF
--- a/checkups/kubevirt-vm-latency/Dockerfile
+++ b/checkups/kubevirt-vm-latency/Dockerfile
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-994
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.1.0-1793
 
-RUN microdnf install shadow-utils && \
+RUN microdnf install -y shadow-utils && \
     adduser --system --no-create-home -u 1001 vm-latency && \
-    microdnf remove shadow-utils && \
+    microdnf remove -y shadow-utils && \
     microdnf clean all
 
 COPY ./bin/kubevirt-vm-latency /usr/bin


### PR DESCRIPTION
In order to address security issues discovered in the current base image, and to get the latest ubi image, update the base image to ubi-minimal 9[1].

Also add `-y` flags to microdnf commands, so they will not hang.

[1] https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5