### PR TITLE
[release-0.2] e2e: Execute on Ubuntu 20.04

### DIFF
--- a/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
+++ b/.github/workflows/checkup-kubevirt-vm-latency.check.yaml
@@ -77,7 +77,7 @@ jobs:
         run: ./automation/make.sh --build-checkup
   e2e-test:
     name: e2e
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CRI: docker
       KUBEVIRT_USE_EMULATION: true


### PR DESCRIPTION
Currently, the e2e tests are failing on `ubuntu-latest` (Ubuntu-22.04).

Execute the e2e tests on `ubuntu-20.04`.

https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/