### PR TITLE
VMLatency: Fix ping parser warning message

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/latency.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/latency.go
@@ -57,9 +57,12 @@ func (l *Latency) CheckDuration() time.Duration {
 
 func (l *Latency) Check(sourceVMI, targetVMI *kvcorev1.VirtualMachineInstance, sampleTime time.Duration) error {
 	const errMessagePrefix = "failed to run check"
+
+	var err error
+
 	sourceVMIConsole := console.NewConsole(l.client, sourceVMI)
 
-	if err := sourceVMIConsole.LoginToAlpine(); err != nil {
+	if err = sourceVMIConsole.LoginToAlpine(); err != nil {
 		return fmt.Errorf("%s: %v", errMessagePrefix, err)
 	}
 
@@ -71,7 +74,11 @@ func (l *Latency) Check(sourceVMI, targetVMI *kvcorev1.VirtualMachineInstance, s
 	if err != nil {
 		return err
 	}
-	l.results = ParsePingResults(res)
+
+	l.results, err = ParsePingResults(res)
+	if err != nil {
+		return err
+	}
 
 	if l.results.Time == 0 {
 		l.results.Time = pingTime

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser.go
@@ -37,7 +37,7 @@ type Results struct {
 	Received    int
 }
 
-func ParsePingResults(pingResult string) Results {
+func ParsePingResults(pingResult string) (Results, error) {
 	const (
 		errMessagePrefix = "ping parser"
 
@@ -78,5 +78,5 @@ func ParsePingResults(pingResult string) Results {
 		}
 	}
 
-	return results
+	return results, nil
 }

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
@@ -57,5 +57,8 @@ round-trip min/avg/max = 0.314/0.368/0.461 ms
 	expectedResults.Max, err = time.ParseDuration("0.461ms")
 	assert.NoError(t, err)
 
-	assert.Equal(t, expectedResults, latency.ParsePingResults(pingOutput))
+	actualResults, err := latency.ParsePingResults(pingOutput)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedResults, actualResults)
 }

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
@@ -28,40 +28,6 @@ import (
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/latency"
 )
 
-func TestParsePingResults(t *testing.T) {
-	const pingOutput = `
-PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
-64 bytes from 1.1.1.1: icmp_seq=1 ttl=58 time=2.17 ms
-64 bytes from 1.1.1.1: icmp_seq=2 ttl=58 time=1.98 ms
-64 bytes from 1.1.1.1: icmp_seq=3 ttl=58 time=2.38 ms
-64 bytes from 1.1.1.1: icmp_seq=4 ttl=58 time=2.11 ms
-64 bytes from 1.1.1.1: icmp_seq=5 ttl=58 time=1.73 ms
-^C
---- 1.1.1.1 ping statistics ---
-5 packets transmitted, 5 received, 0% packet loss, time 4004ms
-rtt min/avg/max/mdev = 1.732/2.074/2.382/0.214 ms
-`
-	expectedResults := latency.Results{
-		Transmitted: 5,
-		Received:    5,
-	}
-	var err error
-	if expectedResults.Time, err = time.ParseDuration("4004ms"); err != nil {
-		panic(err)
-	}
-	if expectedResults.Min, err = time.ParseDuration("1.732ms"); err != nil {
-		panic(err)
-	}
-	if expectedResults.Average, err = time.ParseDuration("2.074ms"); err != nil {
-		panic(err)
-	}
-	if expectedResults.Max, err = time.ParseDuration("2.382ms"); err != nil {
-		panic(err)
-	}
-
-	assert.Equal(t, latency.ParsePingResults(pingOutput), expectedResults)
-}
-
 func TestParseBusyBoxPingResults(t *testing.T) {
 	const pingOutput = `
 PING 192.168.100.20 (192.168.100.20): 56 data bytes

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/kiagnose/kiagnose/checkups/kubevirt-vm-latency/vmlatency/internal/latency"
 )
 
-func TestParseBusyBoxPingResults(t *testing.T) {
+func TestParsePingResults(t *testing.T) {
 	const pingOutput = `
 PING 192.168.100.20 (192.168.100.20): 56 data bytes
 64 bytes from 192.168.100.20: seq=0 ttl=64 time=0.314 ms
@@ -44,17 +44,18 @@ round-trip min/avg/max = 0.314/0.368/0.461 ms
 	expectedResults := latency.Results{
 		Transmitted: 5,
 		Received:    5,
-	}
-	var err error
-	if expectedResults.Min, err = time.ParseDuration("0.314ms"); err != nil {
-		panic(err)
-	}
-	if expectedResults.Average, err = time.ParseDuration("0.368ms"); err != nil {
-		panic(err)
-	}
-	if expectedResults.Max, err = time.ParseDuration("0.461ms"); err != nil {
-		panic(err)
+		Time:        time.Duration(0),
 	}
 
-	assert.Equal(t, latency.ParsePingResults(pingOutput), expectedResults)
+	var err error
+	expectedResults.Min, err = time.ParseDuration("0.314ms")
+	assert.NoError(t, err)
+
+	expectedResults.Average, err = time.ParseDuration("0.368ms")
+	assert.NoError(t, err)
+
+	expectedResults.Max, err = time.ParseDuration("0.461ms")
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedResults, latency.ParsePingResults(pingOutput))
 }


### PR DESCRIPTION
Currently, there is the following warning message in the
checkup's log:
```
ping parser: failed to parse 'time': time: invalid duration "ms"
```

This is caused because the checkup uses a ping
utility that does not produce the actual duration
which is expected by `ParsePingResults`.

Simplify the `ParsePingResults`:
1. The statistics pattern is unified and simplified.
2. The matching logic is simplified.

Error handling is added.

The packet loss percentage is not parsed, since it is
not part of the `Results` struct.

Fixes [CNV-34488](https://issues.redhat.com/browse/CNV-34488).