### PR TITLE
VMLatency: Bump base image

### DIFF
--- a/checkups/kubevirt-vm-latency/Dockerfile
+++ b/checkups/kubevirt-vm-latency/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3-1475
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-949
 
 RUN microdnf install -y shadow-utils && \
     adduser --system --no-create-home -u 1001 vm-latency && \


### PR DESCRIPTION
Bump the base image version to `9.4-949`.