### PR TITLE
vm latency: Fix error message on 100% packet loss

### DIFF
--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -43,6 +44,8 @@ func ParsePingResults(pingResult string) (Results, error) {
 	)
 
 	const (
+		totalPacketLoss = "100% packet loss"
+
 		statisticsPattern = `(\d+)\s+packets transmitted,\s+(\d+)\s+packets received,\s+(\d+)%\s+packet loss\s+` +
 			`round-trip min/avg/max = (\d+\.\d+)/(\d+\.\d+)/(\d+\.\d+) ms`
 		expectedElements = 7
@@ -52,6 +55,10 @@ func ParsePingResults(pingResult string) (Results, error) {
 		results Results
 		err     error
 	)
+
+	if strings.Contains(pingResult, totalPacketLoss) {
+		return Results{}, fmt.Errorf("%s: no connectivity - 100%% packet loss", errMessagePrefix)
+	}
 
 	matches := regexp.MustCompile(statisticsPattern).FindStringSubmatch(pingResult)
 

--- a/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
+++ b/checkups/kubevirt-vm-latency/vmlatency/internal/latency/pingparser_test.go
@@ -62,3 +62,16 @@ round-trip min/avg/max = 0.314/0.368/0.461 ms
 
 	assert.Equal(t, expectedResults, actualResults)
 }
+
+func TestParsePingResultsCompletePacketLoss(t *testing.T) {
+	const pingOutput = `
+PING 10.14.137.156 (10.14.137.156): 56 data bytes
+
+--- 10.14.137.156 ping statistics ---
+5 packets transmitted, 0 packets received, 100% packet loss
+`
+	actualResults, err := latency.ParsePingResults(pingOutput)
+	assert.Error(t, err, "ping parser: no connectivity - 100% packet loss")
+
+	assert.Equal(t, latency.Results{}, actualResults)
+}


### PR DESCRIPTION
Currently, when there is a 100% packet loss, the user receives the following error message:

```
status.failureReason: 'run: ping parser: input does not match regex'
```

Provide a more meaningful error message:

```
status.failureReason: 'run: ping parser: no connectivity - 100% packet loss'
```